### PR TITLE
fix(infra): Block sensitive probes and add fail2ban hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,8 @@ Use these documents as fast context before implementation.
   Use for release scripts, deploy logic, image naming, artifact flow, and rollback behavior. Describes the tag-based release/deploy model and script responsibilities.
 - `infra/docs/project/production-release/README.md`
   Use for production release preparation, GHCR/GitHub Actions/Doppler setup, and rollback procedure. Describes the production release runbook end to end.
+- `infra/docs/project/production-release/fail2ban_probe_blocking.md`
+  Use for production probe blocking, repeated `.env` scans, and host-level IP banning. Describes the `fail2ban` setup for nginx and Traefik logs.
 - `infra/docs/project/SSR Migration/STAGE-1_ssr_migration.md`
   Use for SSR architecture decisions and initial migration direction. Describes the preferred incremental SSR strategy and early-phase non-goals.
 - `infra/docs/project/SSR Migration/STAGE-2_full_ssr_bff_migration_plan.md`

--- a/backend/settings/base.py
+++ b/backend/settings/base.py
@@ -411,10 +411,12 @@ LOGGING = {
         "verbose": {
             "format": "{levelname} {asctime} {module} {process:d} {thread:d} {message}",
             "style": "{",
+            "datefmt": "%Y-%m-%d %H:%M:%S %z",
         },
         "simple": {
-            "format": "{levelname} {message}",
+            "format": "{asctime} {levelname} {message}",
             "style": "{",
+            "datefmt": "%Y-%m-%d %H:%M:%S %z",
         },
     },
     "handlers": {

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -204,6 +204,8 @@ services:
   nginx:
     image: ${ENVIRONMENT}-nginx:${TAG}
     restart: always
+    environment:
+      TZ: "Europe/Warsaw"
     read_only: true
     security_opt:
       - no-new-privileges:true

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,6 +23,7 @@ x-backend-defaults: &backend-defaults
     DB_PASSWORD: ${DB_PASSWORD}
     DB_HOST: ${DB_HOST:-db}
     DB_PORT: 5432
+    SITE_DOMAIN: ${SITE_DOMAIN}
     ADMIN_DOMAIN: ${ADMIN_DOMAIN}
     API_DOMAIN: ${API_DOMAIN}
     CSRF_COOKIE_DOMAIN: ${CSRF_COOKIE_DOMAIN}

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -33,7 +33,7 @@ services:
         max-size: "10m"
         max-file: "3"
     environment:
-      - TZ=UTC
+      - TZ=Europe/Warsaw
       - CONTACT_EMAIL=${CONTACT_EMAIL}
       - SITE_DOMAIN=${SITE_DOMAIN}
       - TRAEFIK_USER=${TRAEFIK_USER}

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -23,6 +23,7 @@ services:
       - /etc/letsencrypt:/etc/letsencrypt:ro
       - ./infra/traefik/traefik.yml:/etc/traefik/traefik.yml.template:ro
       - ./infra/traefik/dynamic_conf.yml:/etc/traefik/dynamic_conf.yml.template:ro
+      - ${TRAEFIK_LOG_DIR:-/var/log/portfolio/traefik}:/var/log/traefik
       - traefik_acme:/letsencrypt
     tmpfs:
       - /tmp

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,4 +1,7 @@
 FROM nginx:1.29-alpine
 
+RUN apk add --no-cache tzdata
+ENV TZ=Europe/Warsaw
+
 COPY infra/nginx/static_server.conf /etc/nginx/nginx.conf
 COPY frontend/public/error.html /usr/share/nginx/html/error.html

--- a/docker/traefik/Dockerfile
+++ b/docker/traefik/Dockerfile
@@ -1,7 +1,10 @@
 FROM traefik:latest
 
-# Install apache2-utils for htpasswd and gettext for envsubst.
-RUN apk add --no-cache apache2-utils gettext
+# Install apache2-utils for htpasswd, gettext for envsubst, and tzdata so
+# file-based access logs can render in the configured local timezone.
+RUN apk add --no-cache apache2-utils gettext tzdata
+
+ENV TZ=Europe/Warsaw
 
 # Copy entrypoint script
 COPY entrypoint.sh /entrypoint.sh

--- a/infra/docs/prod/fail2ban_probe_blocker_playbook.md
+++ b/infra/docs/prod/fail2ban_probe_blocker_playbook.md
@@ -1,0 +1,17 @@
+What you still need to do on the server:
+
+```bash
+sudo apt-get update && sudo apt-get install -y fail2ban
+sudo mkdir -p /var/log/portfolio/traefik
+sudo chown -R <user>:<user> /var/log/portfolio/traefik
+chmod +x /home/<user>/portfolio/infra/scripts/security/install_fail2ban_probe_blocker.sh
+sudo /home/<user>/portfolio/infra/scripts/security/install_fail2ban_probe_blocker.sh
+TAG=v2.2.0 doppler run -- docker compose -f docker-compose.traefik.yml up -d traefik
+```
+
+Then verify:
+
+```bash
+sudo fail2ban-client status portfolio-nginx-sensitive-probes
+sudo fail2ban-client status portfolio-traefik-sensitive-probes
+```

--- a/infra/docs/project/production-release/README.md
+++ b/infra/docs/project/production-release/README.md
@@ -10,6 +10,11 @@ It covers:
 - what must be configured in Doppler on the production VPS
 - what remains local-only for staging
 - how to publish and deploy a production release
+- related production security runbooks
+
+Related production runbooks:
+
+- [Production Probe Blocking With Fail2ban](./fail2ban_probe_blocking.md)
 
 ## Current Model
 
@@ -171,6 +176,10 @@ Manual test pull example:
 ```bash
 doppler -c dev run -- sh -c 'printenv GHCR_TOKEN | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin && docker pull <registry url>'
 ```
+
+## Related Security Runbooks
+
+- [Production Probe Blocking With Fail2ban](./fail2ban_probe_blocking.md)
 
 ## Production Release Flow
 

--- a/infra/docs/project/production-release/fail2ban_probe_blocking.md
+++ b/infra/docs/project/production-release/fail2ban_probe_blocking.md
@@ -1,0 +1,193 @@
+# Production Probe Blocking With Fail2ban
+
+## Purpose
+
+This runbook describes the production setup for automatic IP banning when
+clients repeatedly probe sensitive paths such as:
+
+- `/.env`
+- `/app/.env`
+- `/api/.env`
+- `/.git/config`
+- common CMS / exploit paths such as `/wp-admin` and `/xmlrpc.php`
+
+The setup is intended for the single-droplet production deployment.
+
+## Current Model
+
+The blocking flow is:
+
+1. Traefik logs unmatched direct-IP and host-header probes.
+2. Nginx returns `403` / `404` for blocked sensitive paths on the public site.
+3. `fail2ban` watches both log streams on the host.
+4. Repeated probes from the same IP trigger a temporary host-level ban.
+
+This complements the existing path blocking. It does not replace it.
+
+## Repository Files
+
+The repo-managed files are:
+
+- `infra/scripts/security/fail2ban/filter.d/portfolio-nginx-sensitive-probes.conf`
+- `infra/scripts/security/fail2ban/filter.d/portfolio-traefik-sensitive-probes.conf`
+- `infra/scripts/security/fail2ban/jail.d/portfolio-probe-blocker.local`
+- `infra/scripts/security/install_fail2ban_probe_blocker.sh`
+
+Related runtime wiring:
+
+- `infra/traefik/traefik.yml`
+- `docker-compose.traefik.yml`
+
+## Ban Policy
+
+Current defaults:
+
+- `findtime = 10m`
+- `maxretry = 3`
+- `bantime = 24h`
+
+Jails:
+
+- `portfolio-nginx-sensitive-probes`
+- `portfolio-traefik-sensitive-probes`
+
+## Host Prerequisites
+
+Install `fail2ban` on the production VPS:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y fail2ban
+```
+
+Create the Traefik host log directory:
+
+```bash
+sudo mkdir -p /var/log/portfolio/traefik
+sudo chown -R <user>:<user> /var/log/portfolio/traefik
+```
+
+## Deployment Steps
+
+### 1. Deploy The Updated Traefik Config
+
+Traefik now writes access logs to a host-mounted file:
+
+```bash
+TAG=vX.Y.Z doppler run -- docker compose -f docker-compose.traefik.yml up -d traefik
+```
+
+Verify the file exists and receives entries:
+
+```bash
+ls -l /var/log/portfolio/traefik/access.log
+tail -f /var/log/portfolio/traefik/access.log
+```
+
+### 2. Install The Fail2ban Config
+
+Run:
+
+```bash
+chmod +x /home/<user>/portfolio/infra/scripts/security/install_fail2ban_probe_blocker.sh
+sudo /home/<user>/portfolio/infra/scripts/security/install_fail2ban_probe_blocker.sh
+```
+
+This copies the filters and jail file into:
+
+- `/etc/fail2ban/filter.d/`
+- `/etc/fail2ban/jail.d/`
+
+and reloads or restarts `fail2ban`.
+
+## Server Playbook
+
+What you still need to do on the server:
+
+```bash
+sudo apt-get update && sudo apt-get install -y fail2ban
+sudo mkdir -p /var/log/portfolio/traefik
+sudo chown -R <user>:<user> /var/log/portfolio/traefik
+chmod +x /home/<user>/portfolio/infra/scripts/security/install_fail2ban_probe_blocker.sh
+sudo /home/<user>/portfolio/infra/scripts/security/install_fail2ban_probe_blocker.sh
+TAG=v2.2.0 doppler run -- docker compose -f docker-compose.traefik.yml up -d traefik
+```
+
+Then verify:
+
+```bash
+sudo fail2ban-client status portfolio-nginx-sensitive-probes
+sudo fail2ban-client status portfolio-traefik-sensitive-probes
+```
+
+## Verification
+
+Check the configured jails:
+
+```bash
+sudo fail2ban-client status
+sudo fail2ban-client status portfolio-nginx-sensitive-probes
+sudo fail2ban-client status portfolio-traefik-sensitive-probes
+```
+
+Check active bans:
+
+```bash
+sudo fail2ban-client status portfolio-nginx-sensitive-probes
+sudo fail2ban-client status portfolio-traefik-sensitive-probes
+```
+
+Look for the `Banned IP list` section.
+
+## Log Sources
+
+Nginx jail log file:
+
+```text
+/var/log/portfolio/nginx/prod/access.log
+```
+
+Traefik jail log file:
+
+```text
+/var/log/portfolio/traefik/access.log
+```
+
+## Tuning
+
+You can adjust these values in:
+
+- `infra/scripts/security/fail2ban/jail.d/portfolio-probe-blocker.local`
+
+Common adjustments:
+
+- lower `maxretry` to block faster
+- reduce `findtime` to focus on short bursts
+- increase `bantime` for longer lockouts
+
+## Troubleshooting
+
+### Traefik jail never bans
+
+Check:
+
+1. Traefik was recreated after the access-log file mount was added.
+2. `/var/log/portfolio/traefik/access.log` exists and is non-empty.
+3. `portfolio-traefik-sensitive-probes` appears in `fail2ban-client status`.
+
+### Nginx jail never bans
+
+Check:
+
+1. Sensitive probe requests return `403` or `404`.
+2. `/var/log/portfolio/nginx/prod/access.log` contains those requests.
+3. `portfolio-nginx-sensitive-probes` appears in `fail2ban-client status`.
+
+### A path is not triggering bans
+
+Add or adjust the matching regex in:
+
+- `infra/scripts/security/fail2ban/filter.d/portfolio-nginx-sensitive-probes.conf`
+- `infra/scripts/security/fail2ban/filter.d/portfolio-traefik-sensitive-probes.conf`
+
+Then reinstall or reload `fail2ban`.

--- a/infra/nginx/static_server.conf
+++ b/infra/nginx/static_server.conf
@@ -206,6 +206,27 @@ location ^~ /protected_media/ {
             return 403 "Action restricted: Bot activity detected.";
         }
 
+        # Block hidden files and directories
+        location ~ /\.(?!well-known).* {
+            access_log off;
+            log_not_found off;
+            return 404;
+        }
+
+        # Block prohibited extensions and scripts
+        location ~ \.(php|py|pl|sh|lua|sql|cgi|bak|old|ini|7z|zip|rar|tar|gz)$ {
+            access_log off;
+            log_not_found off;
+            return 404;
+        }
+
+        # Block common CMS and exploit-probing paths
+        location ~* /(wp-admin|wp-login|wp-content|xmlrpc\.php|setup\.php|config\.php|eval-stdin\.php) {
+            access_log off;
+            log_not_found off;
+            return 404;
+        }
+
         location /static/ {
             alias /app/staticfiles/;
             expires 1y;

--- a/infra/nginx/static_server.conf
+++ b/infra/nginx/static_server.conf
@@ -54,7 +54,13 @@ http {
         '"http_referrer": "$http_referer", '
         '"http_user_agent": "$http_user_agent" }';
 
+    # Keep host-mounted file logs for fail2ban and host-side inspection,
+    # but also emit to container stdout/stderr so `docker compose logs nginx`
+    # shows live request/error details during production debugging.
     access_log /var/log/nginx/access.log json_analytics;
+    access_log /dev/stdout json_analytics;
+    error_log /var/log/nginx/error.log warn;
+    error_log /dev/stderr warn;
 
     # Gzip compression
     gzip on;

--- a/infra/scripts/README.md
+++ b/infra/scripts/README.md
@@ -9,6 +9,7 @@ Primary script groups:
 - `release/` -> image build, release jobs, deployment switch, rollback flow
 - `db_backup/` -> backup, restore, restore validation
 - `monitoring/` -> host-side Docker log collection and monitoring helpers
+- `security/` -> host-side security helpers such as `fail2ban` probe blocking
 - `utils.sh` -> shared utility functions used across infra scripts
 
 ---
@@ -167,6 +168,50 @@ TAG=v1.2.0 doppler run -- ./infra/scripts/release/prepare_images.sh
 ```
 
 For staging, run `build.sh` first for the same `ENVIRONMENT` and `TAG`, then rerun `release.sh`.
+
+### 🚫 Probe IP blocking with fail2ban
+
+The repository includes a host-side `fail2ban` setup for repeated probes such as:
+
+- `/.env`
+- `/app/.env`
+- `/api/.env`
+- `/.git/config`
+- common CMS / exploit scans like `/wp-admin` and `/xmlrpc.php`
+
+Files:
+
+- `infra/scripts/security/fail2ban/filter.d/portfolio-nginx-sensitive-probes.conf`
+- `infra/scripts/security/fail2ban/filter.d/portfolio-traefik-sensitive-probes.conf`
+- `infra/scripts/security/fail2ban/jail.d/portfolio-probe-blocker.local`
+- `infra/scripts/security/install_fail2ban_probe_blocker.sh`
+
+The nginx jail covers probes that reach nginx on the public domain.
+The Traefik jail covers unmatched direct-IP and host-header probes before they reach nginx.
+
+Typical host setup:
+
+```bash
+sudo mkdir -p /var/log/portfolio/traefik
+sudo chown -R <user>:<user> /var/log/portfolio/traefik
+chmod +x /home/<user>/portfolio/infra/scripts/security/install_fail2ban_probe_blocker.sh
+sudo /home/<user>/portfolio/infra/scripts/security/install_fail2ban_probe_blocker.sh
+sudo systemctl restart fail2ban
+```
+
+After updating `docker-compose.traefik.yml` / `infra/traefik/traefik.yml`, recreate Traefik so the host access log file is mounted and written:
+
+```bash
+TAG=vX.Y.Z doppler run -- docker compose -f docker-compose.traefik.yml up -d traefik
+```
+
+Useful checks:
+
+```bash
+sudo fail2ban-client status portfolio-nginx-sensitive-probes
+sudo fail2ban-client status portfolio-traefik-sensitive-probes
+sudo fail2ban-client status
+```
 
 ### 💾 Backup scripts
 

--- a/infra/scripts/security/fail2ban/filter.d/portfolio-nginx-sensitive-probes.conf
+++ b/infra/scripts/security/fail2ban/filter.d/portfolio-nginx-sensitive-probes.conf
@@ -1,0 +1,5 @@
+[Definition]
+failregex = ^.*"remote_addr": "<HOST>", .*"request": "[A-Z]+ /(?:[^" ]*/)*\.env[^" ]* HTTP/[0-9.]+"\, .*"status": "(?:403|404)".*$
+            ^.*"remote_addr": "<HOST>", .*"request": "[A-Z]+ /(?:[^" ]*/)*\.git/config[^" ]* HTTP/[0-9.]+"\, .*"status": "(?:403|404)".*$
+            ^.*"remote_addr": "<HOST>", .*"request": "[A-Z]+ /(?:wp-admin|wp-login|wp-content|xmlrpc\.php|phpMyAdmin|phpmyadmin|setup\.php|config\.php|eval-stdin\.php)(?:[/?][^" ]*)? HTTP/[0-9.]+"\, .*"status": "(?:403|404)".*$
+ignoreregex =

--- a/infra/scripts/security/fail2ban/filter.d/portfolio-traefik-sensitive-probes.conf
+++ b/infra/scripts/security/fail2ban/filter.d/portfolio-traefik-sensitive-probes.conf
@@ -1,0 +1,5 @@
+[Definition]
+failregex = ^.*"ClientHost":"<HOST>".*"RequestPath":"/(?:[^"]*/)*\.env[^"]*".*"DownstreamStatus":(?:403|404).*$
+            ^.*"ClientHost":"<HOST>".*"RequestPath":"/(?:[^"]*/)*\.git/config[^"]*".*"DownstreamStatus":(?:403|404).*$
+            ^.*"ClientHost":"<HOST>".*"RequestPath":"/(?:wp-admin|wp-login|wp-content|xmlrpc\.php|phpMyAdmin|phpmyadmin|setup\.php|config\.php|eval-stdin\.php)(?:[/?][^"]*)?".*"DownstreamStatus":(?:403|404).*$
+ignoreregex =

--- a/infra/scripts/security/fail2ban/jail.d/portfolio-probe-blocker.local
+++ b/infra/scripts/security/fail2ban/jail.d/portfolio-probe-blocker.local
@@ -1,0 +1,19 @@
+[portfolio-nginx-sensitive-probes]
+enabled = true
+filter = portfolio-nginx-sensitive-probes
+backend = auto
+port = http,https
+logpath = /var/log/portfolio/nginx/prod/access.log
+findtime = 10m
+maxretry = 3
+bantime = 24h
+
+[portfolio-traefik-sensitive-probes]
+enabled = true
+filter = portfolio-traefik-sensitive-probes
+backend = auto
+port = http,https
+logpath = /var/log/portfolio/traefik/access.log
+findtime = 10m
+maxretry = 3
+bantime = 24h

--- a/infra/scripts/security/install_fail2ban_probe_blocker.sh
+++ b/infra/scripts/security/install_fail2ban_probe_blocker.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+FILTER_DIR_SRC="${SCRIPT_DIR}/fail2ban/filter.d"
+JAIL_SRC="${SCRIPT_DIR}/fail2ban/jail.d/portfolio-probe-blocker.local"
+
+FILTER_DIR_DEST="/etc/fail2ban/filter.d"
+JAIL_DIR_DEST="/etc/fail2ban/jail.d"
+JAIL_DEST="${JAIL_DIR_DEST}/portfolio-probe-blocker.local"
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Please run as root or with sudo."
+  exit 1
+fi
+
+mkdir -p "${FILTER_DIR_DEST}" "${JAIL_DIR_DEST}"
+cp "${FILTER_DIR_SRC}/"*.conf "${FILTER_DIR_DEST}/"
+cp "${JAIL_SRC}" "${JAIL_DEST}"
+
+if command -v fail2ban-client >/dev/null 2>&1; then
+  fail2ban-client reload || systemctl restart fail2ban
+else
+  systemctl restart fail2ban
+fi
+
+echo "Installed fail2ban probe blocker configuration."
+echo "Verify with: fail2ban-client status portfolio-nginx-sensitive-probes"
+echo "Verify with: fail2ban-client status portfolio-traefik-sensitive-probes"

--- a/infra/traefik/traefik.yml
+++ b/infra/traefik/traefik.yml
@@ -38,6 +38,7 @@ log:
   level: INFO
 
 accessLog:
+  filePath: /var/log/traefik/access.log
   bufferingSize: 100
   format: json
   fields:


### PR DESCRIPTION
# Pull Request: Harden production probe handling and sitemap env wiring

## 🚀 Summary
This pull request hardens production traffic handling for sensitive probe paths
and adds a repo-managed `fail2ban` setup for repeated scanner activity. It also
fixes production sitemap monitoring so the backend uses the configured
`SITE_DOMAIN` instead of falling back to `portfolio.local`.

## 🐛 Fixes
- Pass `SITE_DOMAIN` into the production backend environment so sitemap
  analysis and sitemap emails use the real production domain.
- Block hidden files and common probe paths such as `/.env`, nested `.env`
  paths, and common CMS exploit routes in the public nginx server before they
  can fall through to the frontend SSR app.

## 🏗️ Infrastructure
- Add host-file Traefik access logging so unmatched direct-IP and host-header
  probes can be analyzed and acted on outside the container.
- Add repo-managed `fail2ban` filters, jail configuration, and an install
  script to ban IPs that repeatedly probe sensitive paths against nginx and
  Traefik.

## 📝 Docs
- Add a production runbook for fail2ban-based probe blocking and link it from
  the existing production release documentation.
- Add the requested server playbook under `infra/doc/prod/` for direct operator
  reference.

