### PR TITLE
fix(infra): Harden Traefik fail2ban probe blocking

### DIFF
--- a/docker/traefik/entrypoint.sh
+++ b/docker/traefik/entrypoint.sh
@@ -6,6 +6,8 @@ TRAEFIK_TEMPLATE="/etc/traefik/traefik.yml.template"
 TRAEFIK_RENDERED="/tmp/traefik.yml"
 TRAEFIK_DYNAMIC_TEMPLATE="/etc/traefik/dynamic_conf.yml.template"
 TRAEFIK_DYNAMIC_RENDERED="/tmp/dynamic_conf.yml"
+TRAEFIK_LOG_DIR="/var/log/traefik"
+TRAEFIK_ACCESS_LOG="$TRAEFIK_LOG_DIR/access.log"
 ACME_DIR="/letsencrypt"
 ACME_FILE="$ACME_DIR/acme.json"
 
@@ -24,6 +26,19 @@ chmod 600 "$HTPASSWD_FILE"
 mkdir -p "$ACME_DIR"
 touch "$ACME_FILE"
 chmod 600 "$ACME_FILE"
+
+# Prepare the host-mounted access log before Traefik starts so file logging
+# works consistently for fail2ban-backed probe blocking.
+mkdir -p "$TRAEFIK_LOG_DIR"
+touch "$TRAEFIK_ACCESS_LOG"
+chmod 755 "$TRAEFIK_LOG_DIR" || true
+chmod 644 "$TRAEFIK_ACCESS_LOG" || true
+
+if [ ! -w "$TRAEFIK_ACCESS_LOG" ]; then
+    echo "Traefik access log is not writable: $TRAEFIK_ACCESS_LOG" >&2
+    echo "Check the host bind mount permissions for $TRAEFIK_LOG_DIR." >&2
+    exit 1
+fi
 
 if [ ! -f "$TRAEFIK_TEMPLATE" ]; then
     echo "Traefik config template not found: $TRAEFIK_TEMPLATE" >&2

--- a/infra/docs/prod/fail2ban_probe_blocker_playbook.md
+++ b/infra/docs/prod/fail2ban_probe_blocker_playbook.md
@@ -1,17 +1,131 @@
-What you still need to do on the server:
+# Fail2ban Probe Blocker Playbook
+
+Use this when enabling or operating production probe blocking on the VPS.
+
+## Install / Enable
+
+Run these commands on the production server:
 
 ```bash
-sudo apt-get update && sudo apt-get install -y fail2ban
+sudo apt-get update
+sudo apt-get install -y fail2ban
+
 sudo mkdir -p /var/log/portfolio/traefik
-sudo chown -R <user>:<user> /var/log/portfolio/traefik
-chmod +x /home/<user>/portfolio/infra/scripts/security/install_fail2ban_probe_blocker.sh
-sudo /home/<user>/portfolio/infra/scripts/security/install_fail2ban_probe_blocker.sh
+sudo touch /var/log/portfolio/traefik/access.log
+
+chmod +x /home/lukasz/portfolio/infra/scripts/security/install_fail2ban_probe_blocker.sh
+sudo /home/lukasz/portfolio/infra/scripts/security/install_fail2ban_probe_blocker.sh
+
 TAG=v2.2.0 doppler run -- docker compose -f docker-compose.traefik.yml up -d traefik
+sudo systemctl enable --now fail2ban
+TAG=v2.2.0 doppler run -- docker compose -f docker-compose.traefik.yml up -d --force-recreate traefik
 ```
 
-Then verify:
+The installer now detects the active nginx access-log path automatically and installs the shorter jail names required by `iptables`.
+
+## Verify
+
+Check service health and jail registration:
 
 ```bash
-sudo fail2ban-client status portfolio-nginx-sensitive-probes
-sudo fail2ban-client status portfolio-traefik-sensitive-probes
+sudo systemctl status fail2ban --no-pager -l
+sudo journalctl -u fail2ban -n 50 --no-pager
+sudo fail2ban-client status
+sudo fail2ban-client status portfolio-nginx-probes
+sudo fail2ban-client status portfolio-traefik-probes
 ```
+
+Check whether the watched files are receiving traffic:
+
+```bash
+sudo ls -l /etc/nginx/logs/access.log
+sudo tail -n 20 /etc/nginx/logs/access.log
+
+sudo ls -l /var/log/portfolio/traefik/access.log
+sudo tail -n 20 /var/log/portfolio/traefik/access.log
+```
+
+If Traefik fails to start because the host-mounted access log is not writable, the container entrypoint now exits with a clear error instead of silently running without file logging. Check:
+
+```bash
+docker logs --tail 50 traefik
+docker exec traefik sh -lc 'ls -ld /var/log/traefik && ls -l /var/log/traefik'
+```
+
+## Test Nginx Ban Flow
+
+Generate a few blocked requests:
+
+```bash
+for i in 1 2 3; do curl -I https://lukaszremkowicz.com/.env; done
+sudo fail2ban-client status portfolio-nginx-probes
+sudo tail -n 20 /var/log/fail2ban.log
+```
+
+Expected result:
+
+- `Currently banned: 1`
+- the offending IP appears in `Banned IP list`
+- `/var/log/fail2ban.log` shows `NOTICE [portfolio-nginx-probes] Ban <ip>`
+
+## Monitor
+
+Useful day-to-day monitoring commands:
+
+```bash
+sudo fail2ban-client status
+sudo fail2ban-client status portfolio-nginx-probes
+sudo fail2ban-client status portfolio-traefik-probes
+
+sudo tail -f /var/log/fail2ban.log
+sudo journalctl -u fail2ban -f
+
+sudo tail -f /etc/nginx/logs/access.log
+sudo tail -f /var/log/portfolio/traefik/access.log
+```
+
+## Restart / Reload
+
+Use these when updating config or recovering the service:
+
+```bash
+sudo systemctl restart fail2ban
+sudo systemctl status fail2ban --no-pager -l
+
+sudo fail2ban-client reload
+sudo fail2ban-client status
+
+TAG=v2.2.0 doppler run -- docker compose -f docker-compose.traefik.yml up -d --force-recreate traefik
+docker logs --tail 50 traefik
+```
+
+## Clean Banned IPs
+
+Unban a single IP:
+
+```bash
+sudo fail2ban-client set portfolio-nginx-probes unbanip <ip>
+sudo fail2ban-client set portfolio-traefik-probes unbanip <ip>
+```
+
+Clear all bans by restarting the service:
+
+```bash
+sudo systemctl restart fail2ban
+```
+
+## Troubleshooting
+
+If `fail2ban-client` reports a missing socket immediately after restart, wait a moment and retry. That can happen during service startup.
+
+If the nginx jail sees failures but does not ban, check `/var/log/fail2ban.log` for `iptables` errors. Long jail names break chain creation, which is why the server must use:
+
+- `portfolio-nginx-probes`
+- `portfolio-traefik-probes`
+
+If the Traefik jail stays empty, confirm:
+
+- the `traefik` container was recreated
+- `/var/log/portfolio/traefik/access.log` is mounted and non-empty
+- the jail appears in `sudo fail2ban-client status`
+- `docker logs --tail 50 traefik` does not show `Traefik access log is not writable`

--- a/infra/docs/project/production-release/fail2ban_probe_blocking.md
+++ b/infra/docs/project/production-release/fail2ban_probe_blocking.md
@@ -48,8 +48,8 @@ Current defaults:
 
 Jails:
 
-- `portfolio-nginx-sensitive-probes`
-- `portfolio-traefik-sensitive-probes`
+- `portfolio-nginx-probes`
+- `portfolio-traefik-probes`
 
 ## Host Prerequisites
 
@@ -64,7 +64,7 @@ Create the Traefik host log directory:
 
 ```bash
 sudo mkdir -p /var/log/portfolio/traefik
-sudo chown -R <user>:<user> /var/log/portfolio/traefik
+sudo touch /var/log/portfolio/traefik/access.log
 ```
 
 ## Deployment Steps
@@ -89,8 +89,9 @@ tail -f /var/log/portfolio/traefik/access.log
 Run:
 
 ```bash
-chmod +x /home/<user>/portfolio/infra/scripts/security/install_fail2ban_probe_blocker.sh
-sudo /home/<user>/portfolio/infra/scripts/security/install_fail2ban_probe_blocker.sh
+chmod +x /home/lukasz/portfolio/infra/scripts/security/install_fail2ban_probe_blocker.sh
+sudo /home/lukasz/portfolio/infra/scripts/security/install_fail2ban_probe_blocker.sh
+sudo systemctl enable --now fail2ban
 ```
 
 This copies the filters and jail file into:
@@ -105,19 +106,24 @@ and reloads or restarts `fail2ban`.
 What you still need to do on the server:
 
 ```bash
-sudo apt-get update && sudo apt-get install -y fail2ban
+sudo apt-get update
+sudo apt-get install -y fail2ban
 sudo mkdir -p /var/log/portfolio/traefik
-sudo chown -R <user>:<user> /var/log/portfolio/traefik
-chmod +x /home/<user>/portfolio/infra/scripts/security/install_fail2ban_probe_blocker.sh
-sudo /home/<user>/portfolio/infra/scripts/security/install_fail2ban_probe_blocker.sh
+sudo touch /var/log/portfolio/traefik/access.log
+chmod +x /home/lukasz/portfolio/infra/scripts/security/install_fail2ban_probe_blocker.sh
+sudo /home/lukasz/portfolio/infra/scripts/security/install_fail2ban_probe_blocker.sh
 TAG=v2.2.0 doppler run -- docker compose -f docker-compose.traefik.yml up -d traefik
+sudo systemctl enable --now fail2ban
+TAG=v2.2.0 doppler run -- docker compose -f docker-compose.traefik.yml up -d --force-recreate traefik
 ```
 
 Then verify:
 
 ```bash
-sudo fail2ban-client status portfolio-nginx-sensitive-probes
-sudo fail2ban-client status portfolio-traefik-sensitive-probes
+sudo systemctl status fail2ban --no-pager -l
+sudo fail2ban-client status
+sudo fail2ban-client status portfolio-nginx-probes
+sudo fail2ban-client status portfolio-traefik-probes
 ```
 
 ## Verification
@@ -126,15 +132,15 @@ Check the configured jails:
 
 ```bash
 sudo fail2ban-client status
-sudo fail2ban-client status portfolio-nginx-sensitive-probes
-sudo fail2ban-client status portfolio-traefik-sensitive-probes
+sudo fail2ban-client status portfolio-nginx-probes
+sudo fail2ban-client status portfolio-traefik-probes
 ```
 
 Check active bans:
 
 ```bash
-sudo fail2ban-client status portfolio-nginx-sensitive-probes
-sudo fail2ban-client status portfolio-traefik-sensitive-probes
+sudo fail2ban-client status portfolio-nginx-probes
+sudo fail2ban-client status portfolio-traefik-probes
 ```
 
 Look for the `Banned IP list` section.
@@ -144,7 +150,7 @@ Look for the `Banned IP list` section.
 Nginx jail log file:
 
 ```text
-/var/log/portfolio/nginx/prod/access.log
+/var/log/portfolio/nginx/prod/access.log or /etc/nginx/logs/access.log
 ```
 
 Traefik jail log file:
@@ -173,15 +179,16 @@ Check:
 
 1. Traefik was recreated after the access-log file mount was added.
 2. `/var/log/portfolio/traefik/access.log` exists and is non-empty.
-3. `portfolio-traefik-sensitive-probes` appears in `fail2ban-client status`.
+3. `portfolio-traefik-probes` appears in `fail2ban-client status`.
 
 ### Nginx jail never bans
 
 Check:
 
 1. Sensitive probe requests return `403` or `404`.
-2. `/var/log/portfolio/nginx/prod/access.log` contains those requests.
-3. `portfolio-nginx-sensitive-probes` appears in `fail2ban-client status`.
+2. `/etc/nginx/logs/access.log` contains those requests.
+3. `portfolio-nginx-probes` appears in `fail2ban-client status`.
+4. `/var/log/fail2ban.log` does not show an `iptables` chain-name-too-long error.
 
 ### A path is not triggering bans
 
@@ -191,3 +198,43 @@ Add or adjust the matching regex in:
 - `infra/scripts/security/fail2ban/filter.d/portfolio-traefik-sensitive-probes.conf`
 
 Then reinstall or reload `fail2ban`.
+
+## Operations
+
+Monitor service and bans:
+
+```bash
+sudo systemctl status fail2ban --no-pager -l
+sudo fail2ban-client status
+sudo fail2ban-client status portfolio-nginx-probes
+sudo fail2ban-client status portfolio-traefik-probes
+sudo tail -f /var/log/fail2ban.log
+sudo journalctl -u fail2ban -f
+```
+
+Check Traefik access-log health:
+
+```bash
+docker logs --tail 50 traefik
+docker exec traefik sh -lc 'ls -ld /var/log/traefik && ls -l /var/log/traefik'
+```
+
+Restart or reload:
+
+```bash
+sudo systemctl restart fail2ban
+sudo fail2ban-client reload
+```
+
+Remove bans:
+
+```bash
+sudo fail2ban-client set portfolio-nginx-probes unbanip <ip>
+sudo fail2ban-client set portfolio-traefik-probes unbanip <ip>
+```
+
+To clear all bans quickly, restart the service:
+
+```bash
+sudo systemctl restart fail2ban
+```

--- a/infra/scripts/security/fail2ban/filter.d/portfolio-traefik-sensitive-probes.conf
+++ b/infra/scripts/security/fail2ban/filter.d/portfolio-traefik-sensitive-probes.conf
@@ -1,5 +1,5 @@
 [Definition]
-failregex = ^.*"ClientHost":"<HOST>".*"RequestPath":"/(?:[^"]*/)*\.env[^"]*".*"DownstreamStatus":(?:403|404).*$
-            ^.*"ClientHost":"<HOST>".*"RequestPath":"/(?:[^"]*/)*\.git/config[^"]*".*"DownstreamStatus":(?:403|404).*$
-            ^.*"ClientHost":"<HOST>".*"RequestPath":"/(?:wp-admin|wp-login|wp-content|xmlrpc\.php|phpMyAdmin|phpmyadmin|setup\.php|config\.php|eval-stdin\.php)(?:[/?][^"]*)?".*"DownstreamStatus":(?:403|404).*$
+failregex = ^.*"ClientHost":"<HOST>".*"DownstreamStatus":(?:403|404).*"RequestPath":"/(?:[^"]*/)*\.env[^"]*".*$
+            ^.*"ClientHost":"<HOST>".*"DownstreamStatus":(?:403|404).*"RequestPath":"/(?:[^"]*/)*\.git/config[^"]*".*$
+            ^.*"ClientHost":"<HOST>".*"DownstreamStatus":(?:403|404).*"RequestPath":"/(?:wp-admin|wp-login|wp-content|xmlrpc\.php|phpMyAdmin|phpmyadmin|setup\.php|config\.php|eval-stdin\.php)(?:[/?][^"]*)?".*$
 ignoreregex =

--- a/infra/scripts/security/fail2ban/jail.d/portfolio-probe-blocker.local
+++ b/infra/scripts/security/fail2ban/jail.d/portfolio-probe-blocker.local
@@ -1,14 +1,14 @@
-[portfolio-nginx-sensitive-probes]
+[portfolio-nginx-probes]
 enabled = true
 filter = portfolio-nginx-sensitive-probes
 backend = auto
 port = http,https
-logpath = /var/log/portfolio/nginx/prod/access.log
+logpath = __NGINX_ACCESS_LOG__
 findtime = 10m
 maxretry = 3
 bantime = 24h
 
-[portfolio-traefik-sensitive-probes]
+[portfolio-traefik-probes]
 enabled = true
 filter = portfolio-traefik-sensitive-probes
 backend = auto

--- a/infra/scripts/security/install_fail2ban_probe_blocker.sh
+++ b/infra/scripts/security/install_fail2ban_probe_blocker.sh
@@ -8,15 +8,37 @@ JAIL_SRC="${SCRIPT_DIR}/fail2ban/jail.d/portfolio-probe-blocker.local"
 FILTER_DIR_DEST="/etc/fail2ban/filter.d"
 JAIL_DIR_DEST="/etc/fail2ban/jail.d"
 JAIL_DEST="${JAIL_DIR_DEST}/portfolio-probe-blocker.local"
+TRAEFIK_LOG_DIR="/var/log/portfolio/traefik"
+TRAEFIK_LOG_FILE="${TRAEFIK_LOG_DIR}/access.log"
 
 if [ "$(id -u)" -ne 0 ]; then
   echo "Please run as root or with sudo."
   exit 1
 fi
 
+NGINX_LOG_FILE=""
+for candidate in \
+  /var/log/portfolio/nginx/prod/access.log \
+  /etc/nginx/logs/access.log
+do
+  if [ -f "${candidate}" ]; then
+    NGINX_LOG_FILE="${candidate}"
+    break
+  fi
+done
+
+if [ -z "${NGINX_LOG_FILE}" ]; then
+  NGINX_LOG_FILE="/var/log/portfolio/nginx/prod/access.log"
+  mkdir -p "$(dirname "${NGINX_LOG_FILE}")"
+  touch "${NGINX_LOG_FILE}"
+fi
+
+mkdir -p "${TRAEFIK_LOG_DIR}"
+touch "${TRAEFIK_LOG_FILE}"
+
 mkdir -p "${FILTER_DIR_DEST}" "${JAIL_DIR_DEST}"
 cp "${FILTER_DIR_SRC}/"*.conf "${FILTER_DIR_DEST}/"
-cp "${JAIL_SRC}" "${JAIL_DEST}"
+sed "s#__NGINX_ACCESS_LOG__#${NGINX_LOG_FILE}#g" "${JAIL_SRC}" > "${JAIL_DEST}"
 
 if command -v fail2ban-client >/dev/null 2>&1; then
   fail2ban-client reload || systemctl restart fail2ban
@@ -25,5 +47,7 @@ else
 fi
 
 echo "Installed fail2ban probe blocker configuration."
-echo "Verify with: fail2ban-client status portfolio-nginx-sensitive-probes"
-echo "Verify with: fail2ban-client status portfolio-traefik-sensitive-probes"
+echo "Using nginx log path: ${NGINX_LOG_FILE}"
+echo "Using traefik log path: ${TRAEFIK_LOG_FILE}"
+echo "Verify with: fail2ban-client status portfolio-nginx-probes"
+echo "Verify with: fail2ban-client status portfolio-traefik-probes"

--- a/infra/traefik/traefik.yml
+++ b/infra/traefik/traefik.yml
@@ -39,7 +39,8 @@ log:
 
 accessLog:
   filePath: /var/log/traefik/access.log
-  bufferingSize: 100
+  # Flush each request immediately so host-side fail2ban can react in real time.
+  bufferingSize: 0
   format: json
   fields:
     defaultMode: keep


### PR DESCRIPTION
# Pull Request: Harden Traefik and fail2ban probe blocking

## 🚀 Summary
This PR aligns the checked-in Traefik and fail2ban configuration with the production setup validated on the server. It fixes the fail2ban jail naming and log-path issues that blocked bans in production, updates the Traefik probe filter to match the current Traefik 3.6 access-log format, and improves Traefik startup so access-log failures are surfaced clearly.

## 🐛 Fixes
- Shorten fail2ban jail names to `portfolio-nginx-probes` and `portfolio-traefik-probes` so `iptables` chain creation works correctly.
- Update the Traefik probe filter to match the current JSON access-log field order used by Traefik 3.6.
- Disable Traefik access-log buffering so fail2ban can react to probe traffic immediately instead of waiting for buffered flushes.

## 🏗️ Infrastructure
- Harden the Traefik entrypoint to prepare `/var/log/traefik/access.log` before startup and fail fast when the host-mounted access-log path is not writable.
- Update the fail2ban installer to detect the active nginx host log path automatically and render the jail file with the correct `logpath`.
- Ensure the installer creates the Traefik host log file and installs the working probe-blocking configuration without manual server-side `sed` fixes.

## 📝 Docs
- Refresh the production fail2ban playbook with the validated install flow, verification steps, monitoring commands, restart commands, and unban commands.
- Update the production release runbook to reflect the working jail names, nginx log path handling, and Traefik access-log troubleshooting flow.
