### PR TITLE
Normalize stack logging to structured JSON

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,8 @@ Use these documents as fast context before implementation.
   Use for landing-page total-time calculation, `AstroImage.calculated_exposure_hours`, rebuild flow, serializer rounding, and cache invalidation. Describes the current derived-stat architecture and operational caveats.
 - `infra/docs/project/monitoring_system_overview.md`
   Use for monitoring jobs, scheduling, queue routing, log analysis, sitemap analysis, and LLM boundaries. Describes the live monitoring architecture and hard invariants.
+- `infra/docs/project/logging_structure_overview.md`
+  Use for backend/frontend/nginx/Traefik logging formats, JSON-vs-plain-text status, and cross-stack logging structure. Describes how logs are currently emitted across the platform.
 - `collector/README.md`
   Use for the dedicated Python log collector, Docker collector image, manifest-driven source resolution, runtime contract, manual runs, cron installation, and rollout checks. Describes the standalone collector app and its operational boundary.
 - `infra/docs/project/translation_system_overview.md`
@@ -95,6 +97,7 @@ Use this quick mapping when a task arrives:
 - Landing page total-time stat or exposure-hours rebuilds -> `infra/docs/project/landing_page_total_time_spent_system.md`
 - Django admin image cropping or preview/media bug -> `infra/docs/project/django_admin_image_cropper_mechanism.md`
 - Monitoring, Celery monitoring jobs, sitemap checks -> `infra/docs/project/monitoring_system_overview.md`
+- Backend/frontend/nginx/Traefik logging structure -> `infra/docs/project/logging_structure_overview.md`
 - Collector app architecture, manifest contract, rebuild/run path, or cron rollout work -> `collector/README.md`
 - Translation queue/status/admin translation issues -> `infra/docs/project/translation_system_overview.md`
 - Release/deploy script logic or image naming -> `infra/docs/project/release_deploy_architecture.md`

--- a/backend/common/middleware.py
+++ b/backend/common/middleware.py
@@ -14,6 +14,8 @@ from typing import Any
 
 from django.utils import translation
 
+from common.utils.logging import clear_request_log_context, set_request_log_context
+
 logger = logging.getLogger("django.request")
 
 
@@ -36,23 +38,43 @@ class RequestCorrelationMiddleware:
     def __call__(self, request: Any) -> Any:
         request_id = request.META.get("HTTP_X_REQUEST_ID") or str(uuid.uuid4())
         request.request_id = request_id
+        request_method = request.method
+        request_path = request.get_full_path()
+        request_host = request.get_host()
+        set_request_log_context(
+            request_id=request_id,
+            method=request_method,
+            path=request_path,
+            host=request_host,
+        )
 
         started_at = time.monotonic()
-        response = self.get_response(request)
-        duration_ms = int((time.monotonic() - started_at) * 1000)
+        try:
+            response = self.get_response(request)
+        except Exception:
+            duration_ms = int((time.monotonic() - started_at) * 1000)
+            logger.exception(
+                "request_failed",
+                extra={
+                    "status_code": 500,
+                    "duration_ms": duration_ms,
+                },
+            )
+            clear_request_log_context()
+            raise
 
+        duration_ms = int((time.monotonic() - started_at) * 1000)
         response["X-Request-ID"] = request_id
 
         logger.info(
-            "request_id=%s method=%s path=%s status=%s duration_ms=%s host=%s",
-            request_id,
-            request.method,
-            request.get_full_path(),
-            getattr(response, "status_code", "unknown"),
-            duration_ms,
-            request.get_host(),
+            "request_completed",
+            extra={
+                "status_code": getattr(response, "status_code", "unknown"),
+                "duration_ms": duration_ms,
+            },
         )
 
+        clear_request_log_context()
         return response
 
 

--- a/backend/common/utils/logging.py
+++ b/backend/common/utils/logging.py
@@ -11,9 +11,9 @@ parse them reliably. This module provides:
 from __future__ import annotations
 
 import json
-import logging
 from contextvars import ContextVar
 from datetime import UTC, datetime
+from logging import Filter, Formatter, LogRecord
 from typing import Any
 
 _REQUEST_ID: ContextVar[str] = ContextVar("request_id", default="")
@@ -81,14 +81,14 @@ def clear_request_log_context() -> None:
     _REQUEST_HOST.set("")
 
 
-class RequestContextFilter(logging.Filter):
+class RequestContextFilter(Filter):
     """Inject request-scoped metadata into every log record."""
 
     def __init__(self, environment: str = "development") -> None:
         super().__init__()
         self.environment = environment
 
-    def filter(self, record: logging.LogRecord) -> bool:
+    def filter(self, record: LogRecord) -> bool:
         record.environment = self.environment
         record.request_id = _REQUEST_ID.get()
         record.request_method = _REQUEST_METHOD.get()
@@ -97,17 +97,17 @@ class RequestContextFilter(logging.Filter):
         return True
 
 
-class JsonFormatter(logging.Formatter):
+class JsonFormatter(Formatter):
     """Emit one JSON object per log record for Docker stdout consumption."""
 
-    def format(self, record: logging.LogRecord) -> str:
+    def format(self, record: LogRecord) -> str:
         payload = self._build_base_payload(record)
         self._add_request_context(payload, record)
         self._add_extra_fields(payload, record)
         self._add_exception_details(payload, record)
         return json.dumps(payload, ensure_ascii=True, default=str)
 
-    def _build_base_payload(self, record: logging.LogRecord) -> dict[str, Any]:
+    def _build_base_payload(self, record: LogRecord) -> dict[str, Any]:
         return {
             "timestamp": datetime.fromtimestamp(record.created, tz=UTC).isoformat(),
             "level": record.levelname,
@@ -121,13 +121,13 @@ class JsonFormatter(logging.Formatter):
             "environment": getattr(record, "environment", ""),
         }
 
-    def _add_request_context(self, payload: dict[str, Any], record: logging.LogRecord) -> None:
+    def _add_request_context(self, payload: dict[str, Any], record: LogRecord) -> None:
         for field_name in ("request_id", "request_method", "request_path", "request_host"):
             value = getattr(record, field_name, "")
             if value:
                 payload[field_name] = value
 
-    def _add_extra_fields(self, payload: dict[str, Any], record: logging.LogRecord) -> None:
+    def _add_extra_fields(self, payload: dict[str, Any], record: LogRecord) -> None:
         excluded_fields = {
             "environment",
             "request_id",
@@ -142,7 +142,7 @@ class JsonFormatter(logging.Formatter):
                 continue
             payload[key] = self._serialize_extra_value(value)
 
-    def _add_exception_details(self, payload: dict[str, Any], record: logging.LogRecord) -> None:
+    def _add_exception_details(self, payload: dict[str, Any], record: LogRecord) -> None:
         if record.exc_info:
             payload["exception"] = self.formatException(record.exc_info)
 

--- a/backend/common/utils/logging.py
+++ b/backend/common/utils/logging.py
@@ -1,17 +1,157 @@
+"""Shared logging helpers and JSON logging primitives.
+
+The backend writes structured logs to Docker stdout so downstream tooling can
+parse them reliably. This module provides:
+
+- request-scoped logging context via ``contextvars``
+- a logging filter that injects request metadata into every record
+- a JSON formatter that emits one structured JSON object per line
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from contextvars import ContextVar
+from datetime import UTC, datetime
+from typing import Any
+
+_REQUEST_ID: ContextVar[str] = ContextVar("request_id", default="")
+_REQUEST_METHOD: ContextVar[str] = ContextVar("request_method", default="")
+_REQUEST_PATH: ContextVar[str] = ContextVar("request_path", default="")
+_REQUEST_HOST: ContextVar[str] = ContextVar("request_host", default="")
+
+_STANDARD_LOG_RECORD_FIELDS = {
+    "args",
+    "asctime",
+    "created",
+    "exc_info",
+    "exc_text",
+    "filename",
+    "funcName",
+    "levelname",
+    "levelno",
+    "lineno",
+    "module",
+    "msecs",
+    "message",
+    "msg",
+    "name",
+    "pathname",
+    "process",
+    "processName",
+    "relativeCreated",
+    "stack_info",
+    "thread",
+    "threadName",
+    "taskName",
+}
+
+
 def sanitize_for_logging(value: str | None) -> str:
-    """
-    Sanitize a string for logging to prevent log injection (CRLF removal).
-    Also truncates extremely long strings.
-    """
+    """Sanitize a string for structured logging."""
     if not value:
         return ""
 
-    # Remove control characters that could be used for log injection
-    # Replace with space to preserve word separation
     sanitized = value.replace("\n", " ").replace("\r", " ")
-
-    # Truncate if too long (standard log safety)
-    if len(sanitized) > 500:
-        sanitized = sanitized[:497] + "..."
-
+    if len(sanitized) > 1000:
+        return sanitized[:997] + "..."
     return sanitized
+
+
+def set_request_log_context(
+    *,
+    request_id: str,
+    method: str,
+    path: str,
+    host: str,
+) -> None:
+    """Store request context so all logs emitted in-request can include it."""
+    _REQUEST_ID.set(sanitize_for_logging(request_id))
+    _REQUEST_METHOD.set(sanitize_for_logging(method))
+    _REQUEST_PATH.set(sanitize_for_logging(path))
+    _REQUEST_HOST.set(sanitize_for_logging(host))
+
+
+def clear_request_log_context() -> None:
+    """Clear request-scoped logging context after the request finishes."""
+    _REQUEST_ID.set("")
+    _REQUEST_METHOD.set("")
+    _REQUEST_PATH.set("")
+    _REQUEST_HOST.set("")
+
+
+class RequestContextFilter(logging.Filter):
+    """Inject request-scoped metadata into every log record."""
+
+    def __init__(self, environment: str = "development") -> None:
+        super().__init__()
+        self.environment = environment
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.environment = self.environment
+        record.request_id = _REQUEST_ID.get()
+        record.request_method = _REQUEST_METHOD.get()
+        record.request_path = _REQUEST_PATH.get()
+        record.request_host = _REQUEST_HOST.get()
+        return True
+
+
+class JsonFormatter(logging.Formatter):
+    """Emit one JSON object per log record for Docker stdout consumption."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload = self._build_base_payload(record)
+        self._add_request_context(payload, record)
+        self._add_extra_fields(payload, record)
+        self._add_exception_details(payload, record)
+        return json.dumps(payload, ensure_ascii=True, default=str)
+
+    def _build_base_payload(self, record: logging.LogRecord) -> dict[str, Any]:
+        return {
+            "timestamp": datetime.fromtimestamp(record.created, tz=UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "module": record.module,
+            "function": record.funcName,
+            "line": record.lineno,
+            "process": record.process,
+            "thread": record.thread,
+            "message": sanitize_for_logging(record.getMessage()),
+            "environment": getattr(record, "environment", ""),
+        }
+
+    def _add_request_context(self, payload: dict[str, Any], record: logging.LogRecord) -> None:
+        for field_name in ("request_id", "request_method", "request_path", "request_host"):
+            value = getattr(record, field_name, "")
+            if value:
+                payload[field_name] = value
+
+    def _add_extra_fields(self, payload: dict[str, Any], record: logging.LogRecord) -> None:
+        excluded_fields = {
+            "environment",
+            "request_id",
+            "request_method",
+            "request_path",
+            "request_host",
+        }
+        for key, value in record.__dict__.items():
+            if key in _STANDARD_LOG_RECORD_FIELDS or key in excluded_fields or key.startswith("_"):
+                continue
+            if value is None:
+                continue
+            payload[key] = self._serialize_extra_value(value)
+
+    def _add_exception_details(self, payload: dict[str, Any], record: logging.LogRecord) -> None:
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+
+        if record.stack_info:
+            payload["stack"] = sanitize_for_logging(self.formatStack(record.stack_info))
+
+    def _serialize_extra_value(self, value: Any) -> str | int | float | bool:
+        if isinstance(value, str):
+            return sanitize_for_logging(value)
+        if isinstance(value, (int, float, bool)):
+            return value
+        return sanitize_for_logging(repr(value))

--- a/backend/common/utils/logging.py
+++ b/backend/common/utils/logging.py
@@ -10,11 +10,15 @@ parse them reliably. This module provides:
 
 from __future__ import annotations
 
+import importlib
 import json
 from contextvars import ContextVar
 from datetime import UTC, datetime
-from logging import Filter, Formatter, LogRecord
 from typing import Any
+
+_stdlib_logging = importlib.import_module("logging")
+FilterBase: Any = _stdlib_logging.Filter
+FormatterBase: Any = _stdlib_logging.Formatter
 
 _REQUEST_ID: ContextVar[str] = ContextVar("request_id", default="")
 _REQUEST_METHOD: ContextVar[str] = ContextVar("request_method", default="")
@@ -81,14 +85,14 @@ def clear_request_log_context() -> None:
     _REQUEST_HOST.set("")
 
 
-class RequestContextFilter(Filter):
+class RequestContextFilter(FilterBase):
     """Inject request-scoped metadata into every log record."""
 
     def __init__(self, environment: str = "development") -> None:
         super().__init__()
         self.environment = environment
 
-    def filter(self, record: LogRecord) -> bool:
+    def filter(self, record: Any) -> bool:
         record.environment = self.environment
         record.request_id = _REQUEST_ID.get()
         record.request_method = _REQUEST_METHOD.get()
@@ -97,17 +101,17 @@ class RequestContextFilter(Filter):
         return True
 
 
-class JsonFormatter(Formatter):
+class JsonFormatter(FormatterBase):
     """Emit one JSON object per log record for Docker stdout consumption."""
 
-    def format(self, record: LogRecord) -> str:
+    def format(self, record: Any) -> str:
         payload = self._build_base_payload(record)
         self._add_request_context(payload, record)
         self._add_extra_fields(payload, record)
         self._add_exception_details(payload, record)
         return json.dumps(payload, ensure_ascii=True, default=str)
 
-    def _build_base_payload(self, record: LogRecord) -> dict[str, Any]:
+    def _build_base_payload(self, record: Any) -> dict[str, Any]:
         return {
             "timestamp": datetime.fromtimestamp(record.created, tz=UTC).isoformat(),
             "level": record.levelname,
@@ -121,13 +125,13 @@ class JsonFormatter(Formatter):
             "environment": getattr(record, "environment", ""),
         }
 
-    def _add_request_context(self, payload: dict[str, Any], record: LogRecord) -> None:
+    def _add_request_context(self, payload: dict[str, Any], record: Any) -> None:
         for field_name in ("request_id", "request_method", "request_path", "request_host"):
             value = getattr(record, field_name, "")
             if value:
                 payload[field_name] = value
 
-    def _add_extra_fields(self, payload: dict[str, Any], record: LogRecord) -> None:
+    def _add_extra_fields(self, payload: dict[str, Any], record: Any) -> None:
         excluded_fields = {
             "environment",
             "request_id",
@@ -142,7 +146,7 @@ class JsonFormatter(Formatter):
                 continue
             payload[key] = self._serialize_extra_value(value)
 
-    def _add_exception_details(self, payload: dict[str, Any], record: LogRecord) -> None:
+    def _add_exception_details(self, payload: dict[str, Any], record: Any) -> None:
         if record.exc_info:
             payload["exception"] = self.formatException(record.exc_info)
 

--- a/backend/settings/base.py
+++ b/backend/settings/base.py
@@ -421,35 +421,94 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
-    "formatters": {
-        "verbose": {
-            "format": "{levelname} {asctime} {module} {process:d} {thread:d} {message}",
-            "style": "{",
-            "datefmt": "%Y-%m-%d %H:%M:%S %z",
+    "filters": {
+        "request_context": {
+            "()": "common.utils.logging.RequestContextFilter",
+            "environment": ENVIRONMENT,
         },
-        "simple": {
-            "format": "{asctime} {levelname} {message}",
-            "style": "{",
-            "datefmt": "%Y-%m-%d %H:%M:%S %z",
+    },
+    "formatters": {
+        "json": {
+            "()": "common.utils.logging.JsonFormatter",
         },
     },
     "handlers": {
         "console": {
-            "level": "INFO" if not DEBUG else "DEBUG",
+            "level": env.str("LOG_LEVEL", default="DEBUG" if DEBUG else "INFO"),
             "class": "logging.StreamHandler",
-            "formatter": "simple" if not DEBUG else "verbose",
+            "filters": ["request_context"],
+            "formatter": "json",
         },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": env.str("LOG_LEVEL", default="DEBUG" if DEBUG else "INFO"),
     },
     "loggers": {
         "django": {
             "handlers": ["console"],
+            "level": env.str("DJANGO_LOG_LEVEL", default="INFO"),
+            "propagate": False,
+        },
+        "django.request": {
+            "handlers": ["console"],
             "level": "INFO",
-            "propagate": True,
+            "propagate": False,
+        },
+        "django.server": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "django.db.backends": {
+            "handlers": ["console"],
+            "level": env.str("DB_LOG_LEVEL", default="WARNING"),
+            "propagate": False,
+        },
+        "celery": {
+            "handlers": ["console"],
+            "level": env.str("CELERY_LOG_LEVEL", default="INFO"),
+            "propagate": False,
+        },
+        "common": {
+            "handlers": ["console"],
+            "level": env.str("LOG_LEVEL", default="DEBUG" if DEBUG else "INFO"),
+            "propagate": False,
         },
         "core": {
             "handlers": ["console"],
-            "level": "DEBUG" if DEBUG else "INFO",
-            "propagate": True,
+            "level": env.str("LOG_LEVEL", default="DEBUG" if DEBUG else "INFO"),
+            "propagate": False,
+        },
+        "users": {
+            "handlers": ["console"],
+            "level": env.str("LOG_LEVEL", default="DEBUG" if DEBUG else "INFO"),
+            "propagate": False,
+        },
+        "shop": {
+            "handlers": ["console"],
+            "level": env.str("LOG_LEVEL", default="DEBUG" if DEBUG else "INFO"),
+            "propagate": False,
+        },
+        "monitoring": {
+            "handlers": ["console"],
+            "level": env.str("LOG_LEVEL", default="DEBUG" if DEBUG else "INFO"),
+            "propagate": False,
+        },
+        "translation": {
+            "handlers": ["console"],
+            "level": env.str("LOG_LEVEL", default="DEBUG" if DEBUG else "INFO"),
+            "propagate": False,
+        },
+        "astrophotography": {
+            "handlers": ["console"],
+            "level": env.str("LOG_LEVEL", default="DEBUG" if DEBUG else "INFO"),
+            "propagate": False,
+        },
+        "programming": {
+            "handlers": ["console"],
+            "level": env.str("LOG_LEVEL", default="DEBUG" if DEBUG else "INFO"),
+            "propagate": False,
         },
     },
 }

--- a/frontend/server/index.mjs
+++ b/frontend/server/index.mjs
@@ -19,7 +19,7 @@ import { detectLanguage } from './detectLanguage.js';
 import { pipeDocument } from './documentRender.js';
 import { handleBffRequest } from './backendProxy.js';
 import { handleInternalRequest } from './internalCacheRoute.js';
-import { logRequest } from './logging.js';
+import { logError, logRequest, toErrorPayload } from './logging.js';
 import { getRequestId } from './requestMeta.js';
 import { serveStatic } from './staticAssets.js';
 
@@ -116,7 +116,15 @@ const server = http.createServer(async (req, res) => {
       }
     );
   } catch (error) {
-    console.error('[frontend-ssr] request failed', error);
+    logError(
+      {
+        event: 'request_failed',
+        path: req.url || '/',
+        method: req.method,
+        ...toErrorPayload(error),
+      },
+      requestId
+    );
     if (!res.headersSent) {
       res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
       res.end('Internal Server Error');
@@ -138,5 +146,9 @@ const server = http.createServer(async (req, res) => {
 });
 
 server.listen(port, '0.0.0.0', () => {
-  console.log(`[frontend-ssr] listening on 0.0.0.0:${port}`);
+  logRequest({
+    event: 'server_started',
+    host: '0.0.0.0',
+    port,
+  });
 });

--- a/frontend/server/internalCacheRoute.js
+++ b/frontend/server/internalCacheRoute.js
@@ -1,5 +1,5 @@
 import { invalidateCacheTags } from './ssrCache.js';
-import { logRequest } from './logging.js';
+import { logError, logRequest } from './logging.js';
 import {
   assertJsonContentType,
   readJsonBody,
@@ -11,9 +11,13 @@ export const INTERNAL_CACHE_INVALIDATION_ROUTE = '/internal/cache/invalidate';
 function isAuthorizedInternalCacheRequest(req) {
   const expectedToken = process.env.SSR_CACHE_INVALIDATION_TOKEN || '';
   if (!expectedToken) {
-    console.error(
-      '[frontend-ssr] SSR_CACHE_INVALIDATION_TOKEN is not set — rejecting cache invalidation request'
-    );
+    logError({
+      event: 'cache_invalidation_token_missing',
+      path: INTERNAL_CACHE_INVALIDATION_ROUTE,
+      method: req.method,
+      message:
+        'SSR_CACHE_INVALIDATION_TOKEN is not set — rejecting cache invalidation request',
+    });
     return false;
   }
 

--- a/frontend/server/logging.js
+++ b/frontend/server/logging.js
@@ -14,13 +14,85 @@ function getTimestamp() {
     .replace(', ', 'T');
 }
 
+function sanitize(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return value.replace(/\n/g, ' ').replace(/\r/g, ' ');
+  }
+
+  if (
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    Array.isArray(value)
+  ) {
+    return value;
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+    };
+  }
+
+  return value;
+}
+
+function writeJsonLog(level, payload) {
+  const normalized = {
+    timestamp: getTimestamp(),
+    service: 'frontend-ssr',
+    level,
+    ...payload,
+  };
+
+  const line = JSON.stringify(normalized);
+  if (level === 'ERROR') {
+    console.error(line);
+    return;
+  }
+  console.log(line);
+}
+
+export function logEvent(payload, requestId) {
+  writeJsonLog('INFO', {
+    request_id: requestId || '',
+    ...payload,
+  });
+}
+
+export function logWarning(payload, requestId) {
+  writeJsonLog('WARNING', {
+    request_id: requestId || '',
+    ...payload,
+  });
+}
+
+export function logError(payload, requestId) {
+  writeJsonLog('ERROR', {
+    request_id: requestId || '',
+    ...payload,
+  });
+}
+
 export function logRequest(info, requestId) {
-  console.log(
-    JSON.stringify({
-      ts: getTimestamp(),
-      service: 'frontend-ssr',
-      request_id: requestId,
-      ...info,
-    })
-  );
+  logEvent(info, requestId);
+}
+
+export function toErrorPayload(error) {
+  if (error instanceof Error) {
+    return {
+      error_name: error.name,
+      error_message: sanitize(error.message),
+      error_stack: sanitize(error.stack || ''),
+    };
+  }
+
+  return {
+    error_message: sanitize(String(error)),
+  };
 }

--- a/frontend/src/entry-client.tsx
+++ b/frontend/src/entry-client.tsx
@@ -9,8 +9,7 @@ import { createRoot, hydrateRoot } from 'react-dom/client';
 import { DehydratedState, QueryClient } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { BrowserRouter } from 'react-router-dom';
-import './i18n.client';
-import i18n from './i18n.client';
+import i18n, { i18nReady } from './i18n.client';
 import { setLanguageGetter } from './api/api';
 import { initClientServices } from './utils/initClientServices';
 import { getEnv } from './utils/env';
@@ -43,7 +42,9 @@ i18n.on('languageChanged', () => {
   });
 });
 
-function bootstrapApp() {
+async function bootstrapApp() {
+  await i18nReady;
+
   // Initialise browser-only services (Sentry lazy-load)
   initClientServices();
 

--- a/frontend/src/entry-server.tsx
+++ b/frontend/src/entry-server.tsx
@@ -33,6 +33,7 @@ import { fetchTravelHighlightDetail } from './hooks/useTravelHighlightDetail';
 import { APP_ROUTES } from './api/constants';
 import { getDocumentStatusCodeForSettings } from './routing/publicRoutes';
 import type { EnabledFeatures } from './types';
+import { logError, logWarning, toErrorPayload } from '../server/logging.js';
 
 export interface RenderResult {
   html: string;
@@ -99,7 +100,11 @@ async function renderAppToString(element: React.ReactElement): Promise<string> {
         }
       },
       onError(error) {
-        console.error('[frontend-ssr] render error', error);
+        logError({
+          event: 'render_error',
+          stage: 'render_to_string',
+          ...toErrorPayload(error),
+        });
       },
     });
   });
@@ -112,9 +117,10 @@ async function prefetchQuerySafely(
   try {
     await queryClient.prefetchQuery(options);
   } catch (error) {
-    console.warn('[frontend-ssr] prefetch failed', {
-      queryKey: options.queryKey,
-      error: error instanceof Error ? error.message : String(error),
+    logWarning({
+      event: 'prefetch_failed',
+      query_key: options.queryKey,
+      ...toErrorPayload(error),
     });
   }
 }
@@ -126,9 +132,10 @@ async function prefetchInfiniteQuerySafely(
   try {
     await queryClient.prefetchInfiniteQuery(options);
   } catch (error) {
-    console.warn('[frontend-ssr] prefetch failed', {
-      queryKey: options.queryKey,
-      error: error instanceof Error ? error.message : String(error),
+    logWarning({
+      event: 'prefetch_infinite_failed',
+      query_key: options.queryKey,
+      ...toErrorPayload(error),
     });
   }
 }
@@ -392,7 +399,11 @@ export async function renderStream(
         }
       },
       onError(error) {
-        console.error('[frontend-ssr] render error', error);
+        logError({
+          event: 'render_error',
+          stage: 'stream_render',
+          ...toErrorPayload(error),
+        });
       },
     });
   });

--- a/frontend/src/i18n.client.ts
+++ b/frontend/src/i18n.client.ts
@@ -30,7 +30,7 @@ const initialLanguage =
     ? normalizeLanguage(window.__INITIAL_LANGUAGE__)
     : undefined;
 
-i18n
+export const i18nReady = i18n
   .use(HttpApi)
   .use(LanguageDetector)
   .use(initReactI18next)

--- a/infra/docs/project/logging_structure_overview.md
+++ b/infra/docs/project/logging_structure_overview.md
@@ -1,0 +1,519 @@
+# Logging Structure Overview
+
+## Purpose
+
+This document describes the current logging structure across the portfolio stack and clarifies which components already emit JSON logs versus plain-text logs.
+
+It is intended as:
+
+- a current-state reference for future logging work,
+- an operational guide for reading logs across backend, frontend, nginx, and Traefik,
+- a baseline for future log normalization and ingestion work.
+
+Current state verified on 2026-04-17.
+
+## Short Answer
+
+Current JSON logging status:
+
+- Backend Django app: yes, JSON to Docker stdout
+- Frontend SSR request logs: yes, JSON to Docker stdout
+- Nginx access logs: yes, JSON to file and Docker stdout
+- Traefik access logs: yes, JSON to file
+- Traefik runtime logs: yes, JSON
+- Frontend SSR startup/error logs: yes, JSON
+
+Current plain-text / non-JSON areas:
+
+- Backend startup / any non-logging `print` usage: possible plain text
+- Nginx error logs: plain text
+- Shell entrypoint scripts: plain text
+
+So the stack is partially normalized, but not fully JSON everywhere yet.
+
+## Component Status
+
+## 1. Backend Django
+
+### Current format
+
+Backend application logs now use JSON through Django logging configuration in:
+
+- [backend/settings/base.py](/Users/lukaszremkowicz/Projects/landingpage/backend/settings/base.py:421)
+- [backend/common/utils/logging.py](/Users/lukaszremkowicz/Projects/landingpage/backend/common/utils/logging.py:1)
+
+The backend writes logs to standard output through the console handler, which means Docker captures them directly.
+
+### Current structured fields
+
+The backend JSON formatter currently emits fields such as:
+
+- `timestamp`
+- `level`
+- `logger`
+- `module`
+- `function`
+- `line`
+- `process`
+- `thread`
+- `message`
+- `environment`
+
+When the log happens during an HTTP request, it also includes:
+
+- `request_id`
+- `request_method`
+- `request_path`
+- `request_host`
+
+Some log lines also include extra fields such as:
+
+- `status_code`
+- `duration_ms`
+- `exception`
+
+### Backend app / logger namespaces
+
+The current Django logging config explicitly configures these backend app namespaces:
+
+- `common`
+- `core`
+- `users`
+- `shop`
+- `monitoring`
+- `translation`
+- `astrophotography`
+- `programming`
+- `django`
+- `django.request`
+- `django.server`
+- `django.db.backends`
+- `celery`
+
+Each of the app namespaces above currently uses the same JSON formatter and the same stdout handler.
+
+That means the log structure is consistent across those apps:
+
+- `timestamp`
+- `level`
+- `logger`
+- `module`
+- `function`
+- `line`
+- `process`
+- `thread`
+- `message`
+- `environment`
+
+### How logs are structured for specific backend apps
+
+#### `common`
+
+Typical purpose:
+
+- shared services
+- email task dispatch
+- SSR cache invalidation
+- shared image-processing workflow
+
+Common log shape:
+
+- base JSON fields
+- optional request context when called in-request
+- optional task/service extras such as:
+  - `status_code`
+  - `duration_ms`
+  - custom `extra={...}` values
+
+Examples live in:
+
+- [backend/common/tasks.py](/Users/lukaszremkowicz/Projects/landingpage/backend/common/tasks.py:1)
+- [backend/common/ssr_cache.py](/Users/lukaszremkowicz/Projects/landingpage/backend/common/ssr_cache.py:1)
+- [backend/common/image_processing.py](/Users/lukaszremkowicz/Projects/landingpage/backend/common/image_processing.py:1)
+
+#### `core`
+
+Typical purpose:
+
+- shared domain infrastructure
+- `BaseImage` lifecycle
+- cache services
+- shared image task compatibility wrapper
+
+Common log shape:
+
+- base JSON fields
+- optional request context
+- model/task specific extras when provided
+
+Examples live in:
+
+- [backend/core/models.py](/Users/lukaszremkowicz/Projects/landingpage/backend/core/models.py:1)
+- [backend/core/tasks.py](/Users/lukaszremkowicz/Projects/landingpage/backend/core/tasks.py:1)
+- [backend/core/cache_service.py](/Users/lukaszremkowicz/Projects/landingpage/backend/core/cache_service.py:1)
+
+#### `users`
+
+Typical purpose:
+
+- profile/user image lifecycle
+- user/profile admin or API logic
+
+Common log shape:
+
+- base JSON fields
+- request context when logs happen during HTTP request flow
+- cache invalidation or image-processing related extras when provided
+
+Examples live in:
+
+- [backend/users/models.py](/Users/lukaszremkowicz/Projects/landingpage/backend/users/models.py:1)
+- [backend/users/tasks.py](/Users/lukaszremkowicz/Projects/landingpage/backend/users/tasks.py:1)
+
+#### `shop`
+
+Typical purpose:
+
+- shop settings image lifecycle
+- product/shop API and admin logic
+
+Common log shape:
+
+- base JSON fields
+- request context when logs happen during HTTP request flow
+- image-processing extras when provided
+
+Examples live in:
+
+- [backend/shop/models.py](/Users/lukaszremkowicz/Projects/landingpage/backend/shop/models.py:1)
+- [backend/shop/tasks.py](/Users/lukaszremkowicz/Projects/landingpage/backend/shop/tasks.py:1)
+
+#### `monitoring`
+
+Typical purpose:
+
+- log analysis
+- sitemap analysis
+- monitoring agent/tool-loop execution
+
+Common log shape:
+
+- base JSON fields
+- usually no request context, because many logs are task/background-job based
+- monitoring-specific free-form messages and any explicit extra fields
+
+Examples live in:
+
+- [backend/monitoring/tasks.py](/Users/lukaszremkowicz/Projects/landingpage/backend/monitoring/tasks.py:1)
+- [backend/monitoring/services.py](/Users/lukaszremkowicz/Projects/landingpage/backend/monitoring/services.py:1)
+- [backend/monitoring/monitoring_agent_runner.py](/Users/lukaszremkowicz/Projects/landingpage/backend/monitoring/monitoring_agent_runner.py:1)
+
+#### `translation`
+
+Typical purpose:
+
+- translation lifecycle orchestration
+- background translation processing
+
+Current structure:
+
+- same base backend JSON structure
+- request context only when logs happen inside request flow
+
+#### `astrophotography`
+
+Typical purpose:
+
+- gallery/admin flows
+- image/domain operations
+- background-image related flows
+
+Current structure:
+
+- same base backend JSON structure
+- request context when emitted during HTTP requests
+
+Examples live in:
+
+- [backend/astrophotography/models.py](/Users/lukaszremkowicz/Projects/landingpage/backend/astrophotography/models.py:1)
+- [backend/astrophotography/admin.py](/Users/lukaszremkowicz/Projects/landingpage/backend/astrophotography/admin.py:1)
+
+#### `programming`
+
+Typical purpose:
+
+- programming portfolio domain/admin flows
+
+Current structure:
+
+- same base backend JSON structure
+- request context when emitted during HTTP requests
+
+Examples live in:
+
+- [backend/programming/admin.py](/Users/lukaszremkowicz/Projects/landingpage/backend/programming/admin.py:1)
+
+#### `django.request`
+
+This logger is especially important because it now carries request completion/failure events from the request correlation middleware.
+
+Current structured request-event fields:
+
+- base JSON fields
+- `request_id`
+- `request_method`
+- `request_path`
+- `request_host`
+- `status_code`
+- `duration_ms`
+- `exception` for failure events
+
+Current event messages:
+
+- `request_completed`
+- `request_failed`
+
+### Backend structure summary
+
+For backend app namespaces, the structure is unified.
+
+The main differences between apps are not formatter differences but:
+
+- logger name
+- whether request context is present
+- which custom `extra={...}` fields the code adds
+
+### Request correlation
+
+Request correlation comes from:
+
+- [backend/common/middleware.py](/Users/lukaszremkowicz/Projects/landingpage/backend/common/middleware.py:20)
+
+The middleware:
+
+- reuses incoming `X-Request-ID` or creates one,
+- stores request metadata in contextvars,
+- emits structured `request_completed` and `request_failed` logs.
+
+### Conclusion
+
+Backend runtime logging is already JSON and suitable for Docker log parsing.
+
+## 2. Frontend SSR Server
+
+### Current format
+
+Frontend SSR logging is now structured for request, startup, warning, and error paths used by the SSR runtime.
+
+Relevant files:
+
+- [frontend/server/logging.js](/Users/lukaszremkowicz/Projects/landingpage/frontend/server/logging.js:1)
+- [frontend/server/index.mjs](/Users/lukaszremkowicz/Projects/landingpage/frontend/server/index.mjs:1)
+
+The SSR server uses:
+
+- `logRequest(...)` to emit JSON request logs
+- `logEvent(...)` for structured runtime/startup logs
+- `logWarning(...)` for structured warning logs
+- `logError(...)` for structured error logs
+
+### Current structured fields
+
+Frontend SSR logs currently include:
+
+- `timestamp`
+- `service`
+- `level`
+- `request_id`
+- request-specific payload fields such as:
+  - `event`
+  - `kind`
+  - `method`
+  - `path`
+  - `status`
+  - `duration_ms`
+  - optional `error`
+  - optional `error_name`
+  - optional `error_message`
+  - optional `error_stack`
+
+### Conclusion
+
+Frontend SSR server/runtime logging is now JSON in the main request/startup/error paths. Browser-side client `console.*` calls still exist in frontend code, but they are not the same as server runtime logs.
+
+## 3. Nginx
+
+### Current format
+
+Nginx access logging is JSON.
+
+Relevant config:
+
+- [infra/nginx/static_server.conf](/Users/lukaszremkowicz/Projects/landingpage/infra/nginx/static_server.conf:43)
+
+Current access log definition:
+
+- `log_format json_analytics escape=json ...`
+- `access_log /var/log/nginx/access.log json_analytics;`
+- `access_log /dev/stdout json_analytics;`
+
+### Current structured fields
+
+The JSON access log contains:
+
+- `time_local`
+- `remote_addr`
+- `host`
+- `upstream_addr`
+- `request`
+- `status`
+- `body_bytes_sent`
+- `request_time`
+- `upstream_response_time`
+- `upstream_status`
+- `http_referrer`
+- `http_user_agent`
+
+### What is not JSON yet
+
+Nginx error logs are still plain text:
+
+- `error_log /var/log/nginx/error.log warn;`
+- `error_log /dev/stderr warn;`
+
+### Conclusion
+
+Nginx access logs are already JSON and visible through Docker stdout. Nginx error logs are still plain text.
+
+## 4. Traefik
+
+### Current format
+
+Traefik access logging is JSON.
+
+Relevant config:
+
+- [infra/traefik/traefik.yml](/Users/lukaszremkowicz/Projects/landingpage/infra/traefik/traefik.yml:38)
+
+Current access log definition:
+
+- `accessLog.format: json`
+- file output:
+  - `/var/log/traefik/access.log`
+
+### Current structured fields
+
+Traefik access logs keep default fields and explicitly keep:
+
+- `RequestHost`
+- `RouterName`
+- `ServiceName`
+- `ServiceURL`
+
+### Runtime logs
+
+Traefik runtime logs are now configured for JSON through:
+
+- `log.level: INFO`
+- `log.format: json`
+
+### Conclusion
+
+Traefik access logs are JSON and Traefik runtime logs are now configured as JSON too.
+
+## 5. Shell Entrypoints / Startup Scripts
+
+Current startup scripts still emit plain text via shell `echo`.
+
+Examples:
+
+- [docker/backend/entrypoint.sh](/Users/lukaszremkowicz/Projects/landingpage/docker/backend/entrypoint.sh:1)
+- [docker/frontend/entrypoint.sh](/Users/lukaszremkowicz/Projects/landingpage/docker/frontend/entrypoint.sh:1)
+- [docker/traefik/entrypoint.sh](/Users/lukaszremkowicz/Projects/landingpage/docker/traefik/entrypoint.sh:1)
+
+These are operational bootstrap logs, not application logs, and they are currently plain text.
+
+## Current Stack Summary
+
+### Fully or mostly JSON today
+
+- Backend Django runtime logs
+- Frontend SSR request logs
+- Nginx access logs
+- Traefik access logs
+
+### Still plain text today
+
+- Nginx error logs
+- shell entrypoint logs
+
+## Recommended Cross-Stack Field Direction
+
+The stack does not yet use one single field schema everywhere.
+
+Current examples:
+
+- Backend:
+  - `timestamp`
+  - `level`
+  - `logger`
+  - `request_id`
+- Frontend:
+  - `timestamp`
+  - `service`
+  - `level`
+  - `request_id`
+- Nginx:
+  - `time_local`
+  - `request`
+  - `status`
+- Traefik:
+  - Traefik-native JSON field names
+
+For future normalization, a better common field direction would be:
+
+- `timestamp`
+- `service`
+- `component`
+- `level`
+- `message`
+- `request_id`
+- `method`
+- `path`
+- `host`
+- `status_code`
+- `duration_ms`
+- `client_ip`
+- `upstream`
+- `environment`
+
+This does not need to happen immediately, but it is the clean target if the project later adds centralized parsing or dashboards.
+
+## Practical Reading Guide
+
+If you are looking at live Docker logs:
+
+- backend logs are JSON
+- nginx access logs are JSON
+- frontend SSR runtime logs are JSON
+- Traefik runtime/access logs are JSON
+- nginx error lines remain plain text
+
+If you are collecting logs for monitoring/fail2ban:
+
+- Traefik access log file is JSON
+- Nginx access log file is JSON
+- Nginx error log remains plain text
+
+## Verified Sources
+
+- [backend/settings/base.py](/Users/lukaszremkowicz/Projects/landingpage/backend/settings/base.py:421)
+- [backend/common/utils/logging.py](/Users/lukaszremkowicz/Projects/landingpage/backend/common/utils/logging.py:1)
+- [backend/common/middleware.py](/Users/lukaszremkowicz/Projects/landingpage/backend/common/middleware.py:20)
+- [frontend/server/logging.js](/Users/lukaszremkowicz/Projects/landingpage/frontend/server/logging.js:1)
+- [frontend/server/index.mjs](/Users/lukaszremkowicz/Projects/landingpage/frontend/server/index.mjs:1)
+- [infra/nginx/static_server.conf](/Users/lukaszremkowicz/Projects/landingpage/infra/nginx/static_server.conf:43)
+- [infra/traefik/traefik.yml](/Users/lukaszremkowicz/Projects/landingpage/infra/traefik/traefik.yml:38)
+- [docker/backend/entrypoint.sh](/Users/lukaszremkowicz/Projects/landingpage/docker/backend/entrypoint.sh:1)
+- [docker/frontend/entrypoint.sh](/Users/lukaszremkowicz/Projects/landingpage/docker/frontend/entrypoint.sh:1)
+- [docker/traefik/entrypoint.sh](/Users/lukaszremkowicz/Projects/landingpage/docker/traefik/entrypoint.sh:1)

--- a/infra/traefik/traefik.yml
+++ b/infra/traefik/traefik.yml
@@ -36,6 +36,7 @@ certificatesResolvers:
 
 log:
   level: INFO
+  format: json
 
 accessLog:
   filePath: /var/log/traefik/access.log


### PR DESCRIPTION
# Pull Request: Normalize stack logging to structured JSON

## 🚀 Summary
This branch standardizes logging across the stack so the backend, frontend SSR runtime, and Traefik all emit structured JSON logs to Docker stdout. It also adds backend request-context enrichment and documents the current logging structure across platform components and backend app namespaces. The goal is to make logs easier to parse, correlate, and evolve into stronger observability later without changing deployment flow.

## ✨ Features
- Add structured JSON logging for the Django backend with a shared formatter, request-context filter, and consistent logger configuration.
- Add request-scoped metadata to backend logs so in-request events can carry identifiers like request ID, method, path, and host.
- Normalize frontend SSR logging so startup, request failures, SSR render errors, and cache-route errors are emitted as JSON.
- Switch Traefik runtime logs to JSON to align edge logging with the rest of the stack.
- Add a dedicated logging architecture document covering backend, frontend, nginx, and Traefik log structure.
- Add the new logging document to `AGENTS.md` so future work routes to the right runbook quickly.

## 🐛 Fixes
- Remove mixed plain-text versus structured logging behavior in the backend request path.
- Improve error logging consistency for frontend SSR and internal cache invalidation flows.
- Reduce ambiguity around current logging formats by documenting which components already emit JSON and which still need normalization.

## 🔧 Build / CI / Infra
- Configure backend logs for Docker stdout JSON output instead of human-only console formatting.
- Update Traefik logging configuration to emit JSON runtime logs.
- Keep nginx access-log JSON behavior documented while clearly calling out the remaining nginx error-log limitation.
