### PR TITLE
ref(deploy): Harden frontend rollouts and quiet release noise

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,8 @@ Use these documents as fast context before implementation.
   Use for translation lifecycle, `TranslationTask` debugging, translation admin behavior, serializer fallback behavior, and adding translation support to new models. Describes the async translation architecture and its operational boundaries.
 - `infra/docs/project/release_deploy_architecture.md`
   Use for release scripts, deploy logic, image naming, artifact flow, and rollback behavior. Describes the tag-based release/deploy model and script responsibilities.
+- `infra/docs/project/vps_postgres_ssh_tunneling.md`
+  Use for local SSH tunneling into the VPS PostgreSQL container, pgAdmin connection setup, and port-forwarding examples. Describes the local-to-VPS tunnel shape and Docker container IP usage.
 - `infra/docs/prod/fail2ban_probe_blocker_playbook.md`
   Use for production probe blocking, repeated `.env` scans, and host-level IP banning. Describes the `fail2ban` setup for nginx and Traefik logs.
 - `infra/docs/project/SSR Migration/STAGE-1_ssr_migration.md`
@@ -101,6 +103,7 @@ Use this quick mapping when a task arrives:
 - Collector app architecture, manifest contract, rebuild/run path, or cron rollout work -> `collector/README.md`
 - Translation queue/status/admin translation issues -> `infra/docs/project/translation_system_overview.md`
 - Release/deploy script logic or image naming -> `infra/docs/project/release_deploy_architecture.md`
+- SSH tunnel or pgAdmin access to the VPS PostgreSQL DB -> `infra/docs/project/vps_postgres_ssh_tunneling.md`
 - Production release procedure -> `infra/scripts/README.md`
 - SSR architecture direction -> `infra/docs/project/SSR Migration/STAGE-1_ssr_migration.md`
 - BFF route ownership or `/app/...` migration -> `infra/docs/project/SSR Migration/STAGE-2_full_ssr_bff_migration_plan.md`

--- a/backend/common/llm/providers.py
+++ b/backend/common/llm/providers.py
@@ -43,7 +43,7 @@ class MockLLMProvider(LLMProvider):
         temperature: float = 0.0,
     ) -> tuple[str | None, dict]:
         """Mock LLM response for testing purposes."""
-        logger.info("Using mock LLM response for testing purposes.")
+        logger.debug("Using mock LLM response for testing purposes.")
         del system_prompt, user_message, temperature
 
         if self._mock_response is not None:

--- a/backend/common/llm/registry.py
+++ b/backend/common/llm/registry.py
@@ -51,7 +51,7 @@ class LLMProviderRegistry:
             )
 
         cls._providers[name] = provider_class
-        logger.info("Registered LLM provider: %s -> %s", name, provider_class.__name__)
+        logger.debug("Registered LLM provider: %s -> %s", name, provider_class.__name__)
 
     @classmethod
     def get(cls, name: str) -> "LLMProvider":

--- a/backend/core/management/commands/backfill_baseimage_fields.py
+++ b/backend/core/management/commands/backfill_baseimage_fields.py
@@ -73,22 +73,14 @@ class Command(BaseCommand):
         for instance in queryset.iterator():
             updated_fields = self._backfill_instance(instance)
             if updated_fields:
-                instance.save(update_fields=updated_fields)
+                update_values = {
+                    field_name: self._get_field_name(instance, field_name)
+                    for field_name in updated_fields
+                }
+                type(instance).objects.filter(pk=instance.pk).update(**update_values)
                 updated += 1
-                logger.info(
-                    "Backfilled BaseImage fields for instance",
-                    extra={
-                        "target": target.label,
-                        "instance_id": str(instance.pk),
-                        "updated_fields": updated_fields,
-                    },
-                )
             else:
                 skipped += 1
-                logger.info(
-                    "Skipped BaseImage field backfill for instance because nothing changed",
-                    extra={"target": target.label, "instance_id": str(instance.pk)},
-                )
 
         self.stdout.write(
             f"{target.label}: scanned {scanned}, updated {updated}, skipped {skipped}"

--- a/backend/core/tests/test_backfill_baseimage_fields.py
+++ b/backend/core/tests/test_backfill_baseimage_fields.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 
 from django.core.management import call_command
@@ -7,7 +5,6 @@ from django.core.management import call_command
 from astrophotography.models import AstroImage
 from astrophotography.tests.factories import AstroImageFactory
 from core.management.commands.backfill_baseimage_fields import Command
-from scripts.release_entrypoint import RELEASE_CONFIGURATION_COMMANDS
 
 
 @pytest.mark.django_db
@@ -93,8 +90,3 @@ class TestBackfillBaseImageFieldsCommand:
         assert updated_fields == ["original", "original_webp"]
         assert image.original.name == "images/example.jpg"
         assert image.original_webp.name == "images/example.webp"
-
-    def test_release_entrypoint_runs_backfill_command(self) -> None:
-        assert RELEASE_CONFIGURATION_COMMANDS == (
-            (sys.executable, "manage.py", "backfill_baseimage_fields"),
-        )

--- a/backend/scripts/release_entrypoint.py
+++ b/backend/scripts/release_entrypoint.py
@@ -9,7 +9,7 @@ import sys
 logger = logging.getLogger(__name__)
 
 RELEASE_CONFIGURATION_COMMANDS: tuple[tuple[str, ...], ...] = (
-    (sys.executable, "manage.py", "backfill_baseimage_fields"),
+    (sys.executable, "manage.py", "backfill_baseimage_fields", "--verbosity", "0"),
 )
 
 
@@ -18,11 +18,9 @@ def main() -> int:
     for command in RELEASE_CONFIGURATION_COMMANDS:
         printable_command = " ".join(command)
         logger.info("Running release configuration step", extra={"command": printable_command})
-        print(f"Running release configuration step: {printable_command}")
         subprocess.run(command, check=True)
 
     logger.info("Release configuration complete")
-    print("Release configuration complete.")
     return 0
 
 

--- a/backend/scripts/tests/test_release_entrypoint.py
+++ b/backend/scripts/tests/test_release_entrypoint.py
@@ -7,7 +7,7 @@ from scripts.release_entrypoint import RELEASE_CONFIGURATION_COMMANDS, main
 
 def test_release_entrypoint_commands_include_baseimage_backfill() -> None:
     assert RELEASE_CONFIGURATION_COMMANDS == (
-        (sys.executable, "manage.py", "backfill_baseimage_fields"),
+        (sys.executable, "manage.py", "backfill_baseimage_fields", "--verbosity", "0"),
     )
 
 
@@ -18,5 +18,8 @@ def test_release_entrypoint_runs_commands_in_order(mocker: MockerFixture) -> Non
 
     assert result == 0
     assert run_mock.call_args_list == [
-        mocker.call((sys.executable, "manage.py", "backfill_baseimage_fields"), check=True),
+        mocker.call(
+            (sys.executable, "manage.py", "backfill_baseimage_fields", "--verbosity", "0"),
+            check=True,
+        ),
     ]

--- a/backend/settings/base.py
+++ b/backend/settings/base.py
@@ -470,6 +470,11 @@ LOGGING = {
             "level": env.str("CELERY_LOG_LEVEL", default="INFO"),
             "propagate": False,
         },
+        "axes": {
+            "handlers": ["console"],
+            "level": env.str("AXES_LOG_LEVEL", default="WARNING"),
+            "propagate": False,
+        },
         "common": {
             "handlers": ["console"],
             "level": env.str("LOG_LEVEL", default="DEBUG" if DEBUG else "INFO"),

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -150,6 +150,8 @@ services:
     restart: "always"
     networks:
       - portfolio_network
+    volumes:
+      - prod_frontend_asset_cache:/app/runtime-assets
     expose:
       - "8080"
     environment:
@@ -199,7 +201,6 @@ services:
     command: >
       sh -c "
         python manage.py migrate --noinput &&
-        python manage.py seed_settings &&
         python scripts/release_entrypoint.py &&
         python manage.py collectstatic --noinput
       "
@@ -270,6 +271,8 @@ volumes:
   celerybeat_data:
     name: portfolio_prod_celerybeat_data
     external: true
+  prod_frontend_asset_cache:
+    name: portfolio_prod_frontend_asset_cache
   nginx_blocklist:
     name: portfolio_prod_nginx_blocklist
     external: true

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -127,6 +127,8 @@ services:
     restart: always
     networks:
       - stage_network
+    volumes:
+      - portfolio_staging_frontend_asset_cache:/app/runtime-assets
     expose:
       - "8080"
     environment:
@@ -181,7 +183,6 @@ services:
     command: >
       sh -c "
         python manage.py migrate --noinput &&
-        python manage.py seed_settings &&
         python scripts/release_entrypoint.py &&
         python manage.py collectstatic --noinput
       "
@@ -242,3 +243,4 @@ volumes:
     external: true
   portfolio_staging_nginx_blocklist:
     external: true
+  portfolio_staging_frontend_asset_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,7 +175,6 @@ services:
     command: >
       sh -c "
         python manage.py migrate --noinput &&
-        python manage.py seed_settings &&
         python manage.py compilemessages &&
         python manage.py collectstatic --noinput &&
         python manage.py runserver 0.0.0.0:8000

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -46,15 +46,18 @@ ENV NODE_ENV=production
 ENV PORT=8080
 
 COPY --from=build /app/package.json /app/package-lock.json ./
-RUN npm ci --omit=dev
+RUN apk add --no-cache su-exec && npm ci --omit=dev
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/server ./server
 COPY --from=build /app/scripts ./scripts
-
-USER node
+COPY docker/frontend/runtime-entrypoint.sh /usr/local/bin/runtime-entrypoint.sh
+RUN chmod +x /usr/local/bin/runtime-entrypoint.sh && \
+    mkdir -p /app/runtime-assets/current /app/runtime-assets/previous && \
+    chown -R node:node /app/runtime-assets
 
 EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD wget -qO- "http://127.0.0.1:${PORT}/health" >/dev/null || exit 1
+ENTRYPOINT ["runtime-entrypoint.sh"]
 CMD ["npm", "run", "serve:runtime"]
 
 FROM runtime AS prod

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -55,6 +55,6 @@ USER node
 
 EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD wget -qO- "http://127.0.0.1:${PORT}/health" >/dev/null || exit 1
-CMD ["npm", "run", "serve:ssr"]
+CMD ["npm", "run", "serve:runtime"]
 
 FROM runtime AS prod

--- a/docker/frontend/runtime-entrypoint.sh
+++ b/docker/frontend/runtime-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+APP_USER="${APP_USER:-node}"
+RUNTIME_ROOT="${FRONTEND_ASSET_ROOT:-/app/runtime-assets}"
+
+APP_UID="$(id -u "${APP_USER}")"
+APP_GID="$(id -g "${APP_USER}")"
+
+mkdir -p "${RUNTIME_ROOT}/current" "${RUNTIME_ROOT}/previous"
+chown -R "${APP_UID}:${APP_GID}" "${RUNTIME_ROOT}"
+
+exec su-exec "${APP_UID}:${APP_GID}" "$@"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "build:ssr": "npm run build:client && npm run build:server",
     "dev:ssr": "node --watch --watch-path=src/api --watch-path=src/components --watch-path=src/context --watch-path=src/hooks --watch-path=src/styles --watch-path=src/types --watch-path=src/utils --watch-path=src/App.tsx --watch-path=src/AppShell.tsx --watch-path=src/HomePage.tsx --watch-path=src/entry-client.tsx --watch-path=src/entry-server.tsx --watch-path=src/i18n.client.ts --watch-path=src/i18n.server.ts --watch-path=src/i18n.ts --watch-path=src/index.tsx --watch-path=src/service-worker.ts --watch-path=server --watch-path=public --watch-path=index.html scripts/dev-ssr.mjs",
     "serve:ssr": "node server/index.mjs",
+    "serve:runtime": "node scripts/start-runtime.mjs",
     "cache:clear:ssr": "node scripts/clear-ssr-cache.mjs",
     "preview": "vite preview",
     "test": "jest",

--- a/frontend/scripts/start-runtime.mjs
+++ b/frontend/scripts/start-runtime.mjs
@@ -1,0 +1,91 @@
+import { cpSync, existsSync, mkdirSync, rmSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+const appRoot = path.resolve(import.meta.dirname, '..');
+const bundledDistDir = path.join(appRoot, 'dist');
+const assetRoot = process.env.FRONTEND_ASSET_ROOT || '/app/runtime-assets';
+const currentDistDir = path.join(assetRoot, 'current');
+const previousDistDir = path.join(assetRoot, 'previous');
+const serverEntrypoint = path.join(appRoot, 'server', 'index.mjs');
+
+function emitLog(level, message, extra = {}) {
+  process.stdout.write(
+    `${JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level,
+      logger: 'frontend.runtime',
+      module: 'start-runtime',
+      message,
+      environment:
+        process.env.ENVIRONMENT ||
+        process.env.VITE_ENVIRONMENT ||
+        process.env.NODE_ENV ||
+        'development',
+      ...extra,
+    })}\n`
+  );
+}
+
+function copyDirectory(sourceDir, targetDir) {
+  cpSync(sourceDir, targetDir, {
+    dereference: true,
+    errorOnExist: false,
+    force: true,
+    preserveTimestamps: true,
+    recursive: true,
+  });
+}
+
+function prepareRuntimeAssets() {
+  if (!existsSync(bundledDistDir) || !statSync(bundledDistDir).isDirectory()) {
+    emitLog(
+      'WARN',
+      'Skipping runtime asset preparation because dist is missing'
+    );
+    return;
+  }
+
+  mkdirSync(assetRoot, { recursive: true });
+
+  if (existsSync(previousDistDir)) {
+    rmSync(previousDistDir, { force: true, recursive: true });
+  }
+
+  if (existsSync(currentDistDir)) {
+    copyDirectory(currentDistDir, previousDistDir);
+    rmSync(currentDistDir, { force: true, recursive: true });
+  }
+
+  copyDirectory(bundledDistDir, currentDistDir);
+
+  emitLog('INFO', 'Prepared runtime frontend assets', {
+    asset_root: assetRoot,
+    current_dir: currentDistDir,
+    previous_dir: previousDistDir,
+  });
+}
+
+function startServer() {
+  const child = spawn(process.execPath, [serverEntrypoint], {
+    env: {
+      ...process.env,
+      FRONTEND_ASSET_ROOT: assetRoot,
+    },
+    stdio: 'inherit',
+  });
+
+  child.on('exit', code => {
+    process.exit(code ?? 0);
+  });
+
+  child.on('error', error => {
+    emitLog('ERROR', 'Failed to launch frontend runtime server', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    process.exit(1);
+  });
+}
+
+prepareRuntimeAssets();
+startServer();

--- a/frontend/scripts/start-runtime.mjs
+++ b/frontend/scripts/start-runtime.mjs
@@ -43,34 +43,47 @@ function prepareRuntimeAssets() {
       'WARN',
       'Skipping runtime asset preparation because dist is missing'
     );
-    return;
+    return false;
   }
 
-  mkdirSync(assetRoot, { recursive: true });
+  try {
+    mkdirSync(assetRoot, { recursive: true });
 
-  if (existsSync(previousDistDir)) {
-    rmSync(previousDistDir, { force: true, recursive: true });
+    if (existsSync(previousDistDir)) {
+      rmSync(previousDistDir, { force: true, recursive: true });
+    }
+
+    if (existsSync(currentDistDir)) {
+      copyDirectory(currentDistDir, previousDistDir);
+      rmSync(currentDistDir, { force: true, recursive: true });
+    }
+
+    copyDirectory(bundledDistDir, currentDistDir);
+
+    emitLog('INFO', 'Prepared runtime frontend assets', {
+      asset_root: assetRoot,
+      current_dir: currentDistDir,
+      previous_dir: previousDistDir,
+    });
+    return true;
+  } catch (error) {
+    emitLog(
+      'WARN',
+      'Runtime asset preparation failed; serving bundled assets only',
+      {
+        asset_root: assetRoot,
+        error: error instanceof Error ? error.message : String(error),
+      }
+    );
+    return false;
   }
-
-  if (existsSync(currentDistDir)) {
-    copyDirectory(currentDistDir, previousDistDir);
-    rmSync(currentDistDir, { force: true, recursive: true });
-  }
-
-  copyDirectory(bundledDistDir, currentDistDir);
-
-  emitLog('INFO', 'Prepared runtime frontend assets', {
-    asset_root: assetRoot,
-    current_dir: currentDistDir,
-    previous_dir: previousDistDir,
-  });
 }
 
-function startServer() {
+function startServer(useRuntimeAssets) {
   const child = spawn(process.execPath, [serverEntrypoint], {
     env: {
       ...process.env,
-      FRONTEND_ASSET_ROOT: assetRoot,
+      ...(useRuntimeAssets ? { FRONTEND_ASSET_ROOT: assetRoot } : {}),
     },
     stdio: 'inherit',
   });
@@ -87,5 +100,5 @@ function startServer() {
   });
 }
 
-prepareRuntimeAssets();
-startServer();
+const useRuntimeAssets = prepareRuntimeAssets();
+startServer(useRuntimeAssets);

--- a/frontend/server/index.mjs
+++ b/frontend/server/index.mjs
@@ -26,7 +26,14 @@ import { serveStatic } from './staticAssets.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const appRoot = path.resolve(__dirname, '..');
-const clientDistDir = path.join(appRoot, 'dist');
+const bundledClientDistDir = path.join(appRoot, 'dist');
+const frontendAssetRoot = process.env.FRONTEND_ASSET_ROOT || '';
+const clientDistDir = frontendAssetRoot
+  ? path.join(frontendAssetRoot, 'current')
+  : bundledClientDistDir;
+const legacyClientDistDirs = frontendAssetRoot
+  ? [path.join(frontendAssetRoot, 'previous'), bundledClientDistDir]
+  : [];
 const serverEntryPath = path.join(appRoot, 'dist', 'server', 'entry-server.js');
 const indexHtmlPath = path.join(clientDistDir, 'index.html');
 const port = Number(process.env.PORT || process.env.FRONTEND_PORT || 8080);
@@ -72,7 +79,7 @@ const server = http.createServer(async (req, res) => {
       return;
     }
 
-    if (await serveStatic(req, res, clientDistDir)) {
+    if (await serveStatic(req, res, clientDistDir, legacyClientDistDirs)) {
       logRequest(
         {
           kind: 'static',

--- a/frontend/server/staticAssets.js
+++ b/frontend/server/staticAssets.js
@@ -52,11 +52,42 @@ function isSafeStaticPath(pathname, clientDistDir) {
 }
 
 /**
+ * Resolve a requested asset against the current client dist first, then any
+ * older retained dist directories used to bridge deploy transitions.
+ */
+function resolveStaticPath(pathname, clientDistDir, fallbackDistDirs = []) {
+  const candidateDirs = [clientDistDir, ...fallbackDistDirs];
+
+  for (const candidateDir of candidateDirs) {
+    if (!candidateDir || !existsSync(candidateDir)) {
+      continue;
+    }
+
+    const resolvedPath = isSafeStaticPath(pathname, candidateDir);
+    if (resolvedPath && existsSync(resolvedPath)) {
+      return resolvedPath;
+    }
+  }
+
+  return null;
+}
+
+/**
  * Serve a built static asset from the client dist directory.
  */
-export async function serveStatic(req, res, clientDistDir) {
-  const targetPath = isSafeStaticPath(req.url || '/', clientDistDir);
-  if (!targetPath || !existsSync(targetPath)) {
+export async function serveStatic(
+  req,
+  res,
+  clientDistDir,
+  fallbackDistDirs = []
+) {
+  const targetPath = resolveStaticPath(
+    req.url || '/',
+    clientDistDir,
+    fallbackDistDirs
+  );
+
+  if (!targetPath) {
     return false;
   }
 

--- a/frontend/src/components/Shop.tsx
+++ b/frontend/src/components/Shop.tsx
@@ -19,7 +19,7 @@ const Shop: FC = () => {
   const products = data?.products ?? [];
   const title = data?.title || t('shop.title');
   const description = stripHtml(data?.description || '').trim();
-  const backgroundUrl = data?.background_url || '/zodiacal.png';
+  const backgroundUrl = data?.background_url || '';
   const fallbackDescription = t('shop.subtitle');
 
   return (
@@ -33,7 +33,9 @@ const Shop: FC = () => {
       <div className={styles.shopContainer}>
         <div
           className={styles.zodiacalBackground}
-          style={{ backgroundImage: `url('${backgroundUrl}')` }}
+          style={
+            backgroundUrl ? { backgroundImage: `url('${backgroundUrl}')` } : {}
+          }
           aria-hidden='true'
         />
         <div

--- a/frontend/src/entry-client.tsx
+++ b/frontend/src/entry-client.tsx
@@ -13,6 +13,7 @@ import i18n, { i18nReady } from './i18n.client';
 import { setLanguageGetter } from './api/api';
 import { initClientServices } from './utils/initClientServices';
 import { getEnv } from './utils/env';
+import { initPwaRuntime } from './utils/pwaRuntime';
 import AppShell from './AppShell';
 import App from './App';
 
@@ -52,6 +53,7 @@ async function bootstrapApp() {
   if (!rootElement) throw new Error('Root element not found');
 
   const environment = getEnv('ENVIRONMENT', getEnv('NODE_ENV', 'development'));
+  initPwaRuntime(environment);
   // Local development prefers a clean client mount over hydration recovery noise.
   // Production-like environments should hydrate so SSR/client mismatches stay visible.
   const useClientRenderOnly = ['development', 'dev'].includes(environment);

--- a/frontend/src/utils/pwaRuntime.ts
+++ b/frontend/src/utils/pwaRuntime.ts
@@ -1,0 +1,116 @@
+const STALE_CHUNK_RELOAD_KEY = 'portfolio:stale-chunk-reload';
+const SW_UPDATE_RELOAD_KEY = 'portfolio:sw-update-reload';
+const STALE_CHUNK_PATTERNS = [
+  /Failed to fetch dynamically imported module/i,
+  /Importing a module script failed/i,
+  /ChunkLoadError/i,
+  /Loading chunk [\w-]+ failed/i,
+];
+
+function matchesStaleChunkError(value: unknown): boolean {
+  if (value instanceof Error) {
+    return STALE_CHUNK_PATTERNS.some(
+      pattern => pattern.test(value.message) || pattern.test(value.stack || '')
+    );
+  }
+
+  if (typeof value === 'string') {
+    return STALE_CHUNK_PATTERNS.some(pattern => pattern.test(value));
+  }
+
+  return false;
+}
+
+function triggerReloadOnce(storageKey: string): void {
+  const currentUrl = window.location.href;
+
+  if (sessionStorage.getItem(storageKey) === currentUrl) {
+    return;
+  }
+
+  sessionStorage.setItem(storageKey, currentUrl);
+  window.location.reload();
+}
+
+function installStaleChunkRecovery(): void {
+  window.addEventListener(
+    'error',
+    event => {
+      if (matchesStaleChunkError(event.error || event.message)) {
+        triggerReloadOnce(STALE_CHUNK_RELOAD_KEY);
+      }
+    },
+    true
+  );
+
+  window.addEventListener('unhandledrejection', event => {
+    if (matchesStaleChunkError(event.reason)) {
+      triggerReloadOnce(STALE_CHUNK_RELOAD_KEY);
+    }
+  });
+}
+
+async function enablePwaRuntime(): Promise<void> {
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    triggerReloadOnce(SW_UPDATE_RELOAD_KEY);
+  });
+
+  try {
+    const registration =
+      (await navigator.serviceWorker.getRegistration('/')) ||
+      (await navigator.serviceWorker.register('/sw.js'));
+
+    const activateUpdatedWorker = () => {
+      sessionStorage.removeItem(SW_UPDATE_RELOAD_KEY);
+      registration.waiting?.postMessage({ type: 'SKIP_WAITING' });
+    };
+
+    if (registration.waiting) {
+      activateUpdatedWorker();
+    }
+
+    registration.addEventListener('updatefound', () => {
+      const installingWorker = registration.installing;
+      if (!installingWorker) {
+        return;
+      }
+
+      installingWorker.addEventListener('statechange', () => {
+        if (
+          installingWorker.state === 'installed' &&
+          navigator.serviceWorker.controller
+        ) {
+          activateUpdatedWorker();
+        }
+      });
+    });
+
+    void registration.update();
+  } catch (error) {
+    console.error('Failed to register service worker', error);
+  }
+}
+
+function clearReloadGuardsOnSuccessfulLoad(): void {
+  window.addEventListener('pageshow', () => {
+    window.setTimeout(() => {
+      sessionStorage.removeItem(STALE_CHUNK_RELOAD_KEY);
+      sessionStorage.removeItem(SW_UPDATE_RELOAD_KEY);
+    }, 10000);
+  });
+}
+
+export function initPwaRuntime(environment: string): void {
+  installStaleChunkRecovery();
+  clearReloadGuardsOnSuccessfulLoad();
+
+  if (['development', 'dev', 'local'].includes(environment)) {
+    return;
+  }
+
+  if (!('serviceWorker' in navigator)) {
+    return;
+  }
+
+  void enablePwaRuntime();
+}

--- a/infra/docs/project/logging_structure_overview.md
+++ b/infra/docs/project/logging_structure_overview.md
@@ -152,7 +152,6 @@ These modules emit structured logs through the normal app-level namespace config
 - [backend/core/models.py](/Users/lukaszremkowicz/Projects/landingpage/backend/core/models.py:1)
 - [backend/core/tasks.py](/Users/lukaszremkowicz/Projects/landingpage/backend/core/tasks.py:1)
 - [backend/core/management/commands/backfill_baseimage_fields.py](/Users/lukaszremkowicz/Projects/landingpage/backend/core/management/commands/backfill_baseimage_fields.py:1)
-- [backend/scripts/release_entrypoint.py](/Users/lukaszremkowicz/Projects/landingpage/backend/scripts/release_entrypoint.py:1)
 - shared image task compatibility wrapper
 
 Common log shape:

--- a/infra/docs/project/vps_postgres_ssh_tunneling.md
+++ b/infra/docs/project/vps_postgres_ssh_tunneling.md
@@ -1,0 +1,223 @@
+# VPS Postgres SSH Tunneling
+
+## Purpose
+
+This document explains how to connect to the VPS PostgreSQL database from a local machine through an SSH tunnel.
+
+It is intended for local tools such as pgAdmin that need a local TCP endpoint while the database itself stays private inside the VPS Docker network.
+
+## Tunnel Command
+
+Use this command on your local machine:
+
+```bash
+ssh -N -L 25432:172.18.0.2:5432 portfolio
+```
+
+This creates a local SSH tunnel from your machine to the PostgreSQL container running on the VPS.
+
+## What The Command Means
+
+```text
+ssh -N -L 25432:172.18.0.2:5432 portfolio
+```
+
+- `ssh`
+  Starts an SSH connection.
+- `-N`
+  Do not run a remote shell or command. Keep the session open only for port forwarding.
+- `-L`
+  Create local port forwarding.
+- `25432`
+  Local port on your machine. This is the port pgAdmin should use.
+- `172.18.0.2`
+  Target IP used on the remote side of the tunnel.
+  After SSH connects to `portfolio`, the VPS tries to open a connection to `172.18.0.2:5432`.
+  That address is the PostgreSQL container IP inside the VPS Docker bridge network.
+  It is not your local machine, not `localhost` on your machine, and not the public VPS IP.
+  It works because the SSH process is already running on the VPS, and from there Docker container IPs on that network are reachable.
+  To get this IP on the VPS, first find the DB container with `docker ps`, then inspect it, for example:
+  `docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' portfolio-dev-db-1`
+- `5432`
+  PostgreSQL port inside the container.
+- `portfolio`
+  SSH alias for the VPS server from your local SSH config.
+
+## Port Mapping Summary
+
+- Local machine: `127.0.0.1:25432`
+- VPS-side target: `172.18.0.2:5432`
+- SSH hop: `portfolio`
+
+So when pgAdmin connects to `127.0.0.1:25432`, traffic is forwarded through SSH to `172.18.0.2:5432` on the VPS.
+
+## Important Note About The Docker IP
+
+The IP `172.18.0.2` in the SSH command is the PostgreSQL container IP inside the VPS Docker network.
+
+This means:
+
+- it is not a localhost address on the VPS
+- it is not the public VPS address
+- it points directly to the running database container inside Docker networking
+
+If Docker networking changes or the database container is recreated on a different bridge/network, this IP may change. If the tunnel suddenly stops working, verify that the PostgreSQL container still uses `172.18.0.2`.
+
+## How To Get The Docker DB IP On The VPS
+
+You usually obtain the Docker-side database IP on the VPS with `docker inspect`.
+
+In this repository, the Compose service is `db`, and the running container is typically named:
+
+```text
+portfolio-dev-db-1
+```
+
+### 1. Find the PostgreSQL container on the VPS
+
+SSH into the VPS and list containers:
+
+```bash
+ssh portfolio
+docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}'
+```
+
+Look for the Postgres container, for example:
+
+```text
+portfolio-dev-db-1   postgres:18   Up ...
+```
+
+### 2. Read its Docker network IP
+
+```bash
+docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' portfolio-dev-db-1
+```
+
+Example output:
+
+```text
+172.18.0.2
+```
+
+That is the IP you place into the SSH tunnel command:
+
+```bash
+ssh -N -L 25432:172.18.0.2:5432 portfolio
+```
+
+### 3. See the Docker network details if needed
+
+```bash
+docker inspect portfolio-dev-db-1
+```
+
+In the output, check:
+
+- `.NetworkSettings.Networks`
+- the network name
+- the `IPAddress` value
+
+## Why The Docker IP Is Used Here
+
+The tunnel target is:
+
+```text
+172.18.0.2:5432
+```
+
+because SSH runs on the VPS, and from the VPS it can reach the Postgres container on the internal Docker bridge network.
+
+So the flow is:
+
+- pgAdmin connects to `127.0.0.1:25432` on your local machine
+- SSH forwards that traffic to the VPS alias `portfolio`
+- the VPS forwards it to the Docker container IP `172.18.0.2`
+- PostgreSQL receives it on port `5432`
+
+## pgAdmin Configuration Example
+
+Use this configuration in pgAdmin:
+
+- Name: `Portfolio VPS DB (SSH tunnel)`
+- Host name/address: `127.0.0.1`
+- Port: `25432`
+- Maintenance database: `postgres`
+- Username: `<postgres user>`
+- Password: `<postgres password>`
+
+Use the same database credentials that the VPS PostgreSQL container is configured with.
+
+## Why pgAdmin Uses 127.0.0.1
+
+pgAdmin should connect to `127.0.0.1`, not to `172.18.0.2` and not to the VPS hostname.
+
+Reason:
+
+- `172.18.0.2` exists only inside the VPS Docker network
+- your local machine cannot reach that private container IP directly
+- the SSH tunnel exposes the remote database locally on port `25432`
+
+## Cheatsheet
+
+### Start tunnel
+
+```bash
+ssh -N -L 25432:172.18.0.2:5432 portfolio
+```
+
+### Start tunnel in background
+
+```bash
+ssh -f -N -L 25432:172.18.0.2:5432 portfolio
+```
+
+### Test the local forwarded port with psql
+
+```bash
+psql -h 127.0.0.1 -p 25432 -U <postgres user> -d postgres
+```
+
+### Check whether the local tunnel port is listening
+
+```bash
+lsof -iTCP:25432 -sTCP:LISTEN
+```
+
+### Stop a background tunnel
+
+```bash
+pkill -f "ssh -f -N -L 25432:172.18.0.2:5432 portfolio"
+```
+
+## Troubleshooting
+
+### pgAdmin cannot connect
+
+Check:
+
+- the SSH alias `portfolio` works
+- the tunnel command is still running
+- pgAdmin uses `127.0.0.1` as host
+- pgAdmin uses port `25432`
+- PostgreSQL is still listening on `5432` inside the container
+- the container IP is still `172.18.0.2`
+
+### Port `25432` already in use locally
+
+Pick another free local port, for example:
+
+```bash
+ssh -N -L 35432:172.18.0.2:5432 portfolio
+```
+
+Then update pgAdmin to use:
+
+- Host name/address: `127.0.0.1`
+- Port: `35432`
+
+## Security Notes
+
+- The database stays private on the VPS side; only SSH exposes it to your local machine.
+- Prefer binding pgAdmin to the local forwarded port only.
+- Close the tunnel when you no longer need DB access.


### PR DESCRIPTION
# Pull Request: Harden frontend PWA rollouts and reduce release noise

## 🚀 Summary
This branch stabilizes stage and production deploy transitions for the frontend PWA while cleaning up backend release-time logging and BaseImage backfill behavior. The main goal is to stop already-open tabs from breaking on hashed chunk rotations, keep one previous frontend asset set available during deploys, and make the release path quieter and easier to operate.

It also removes a broken Shop fallback asset request and tightens the backend rollout hooks so the image-field backfill stays summary-focused without reintroducing noisy side effects.

## ✨ Features
- Add a frontend runtime bootstrap that prepares `current` and `previous` asset directories before the SSR server starts, so old open tabs can still fetch one retained asset set after a deploy.
- Add client-side PWA runtime handling for stale chunk recovery and explicit service-worker updates, so release transitions recover with a controlled reload instead of failing on chunk 404s.
- Add a root bootstrap entrypoint for the frontend container that repairs the runtime asset volume dynamically, then drops privileges back to the app user before starting the server.

## 🐛 Fixes
- Remove the broken `/zodiacal.png` fallback from the Shop page so the page no longer requests a missing background asset when `background_url` is empty.
- Simplify the BaseImage backfill command to avoid per-row save side effects and repeated cache-invalidation noise while keeping the data copy behavior intact.
- Lower chatty startup logging from LLM provider registration and Axes initialization so release logs are easier to scan for real issues.

## 🔧 Build / CI / Infra
- Update the frontend Docker image to use the runtime bootstrap path and the new startup entrypoint.
- Add persistent frontend asset-cache volumes for stage and production so the retained previous asset set survives container restarts and deploy replacements.
- Keep the existing release flow intact while making the frontend runtime startup self-healing instead of depending on manual volume fixes.

