### PR TITLE
Harden security probes and protected media caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,9 @@ pids/
 *.seed
 *.pid.lock
 
+# Draft project analysis documents
+/infra/docs/project/analysis/
+
 # Coverage directory used by tools like istanbul
 coverage/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,8 +73,12 @@ Use these documents as fast context before implementation.
   Use for translation lifecycle, `TranslationTask` debugging, translation admin behavior, serializer fallback behavior, and adding translation support to new models. Describes the async translation architecture and its operational boundaries.
 - `infra/docs/project/release_deploy_architecture.md`
   Use for release scripts, deploy logic, image naming, artifact flow, and rollback behavior. Describes the tag-based release/deploy model and script responsibilities.
-- `infra/docs/project/NEW/mcp_log_server_architecture.md`
+- `infra/docs/project/analysis/mcp_log_server_architecture.md`
   Use for planning the FastMCP-based log/VPS agent server intended to replace the collector over time. Describes the proposed MCP tool surface, auth model, phased migration, and deterministic log-analysis boundary.
+- `infra/docs/project/analysis/cloudflare_cdn_image_migration_analysis.md`
+  Use for planning Cloudflare CDN/R2 image delivery for frontend-served images, cache-header behavior, and secure full-size image routing. Describes the draft storage/CDN migration direction and known nginx/Traefik cache-policy constraints.
+- `infra/docs/project/analysis/TODO.md`
+  Use for planning image performance work that must preserve astrophotography detail. Describes responsive image variants, frontend `srcset` adoption, public CDN rollout, and explicit original/detail image contracts.
 - `infra/docs/project/vps_postgres_ssh_tunneling.md`
   Use for local SSH tunneling into the VPS PostgreSQL container, pgAdmin connection setup, and port-forwarding examples. Describes the local-to-VPS tunnel shape and Docker container IP usage.
 - `infra/docs/prod/fail2ban_probe_blocker_playbook.md`
@@ -105,7 +109,9 @@ Use this quick mapping when a task arrives:
 - Collector app architecture, manifest contract, rebuild/run path, or cron rollout work -> `collector/README.md`
 - Translation queue/status/admin translation issues -> `infra/docs/project/translation_system_overview.md`
 - Release/deploy script logic or image naming -> `infra/docs/project/release_deploy_architecture.md`
-- FastMCP log/VPS agent server planning or collector replacement -> `infra/docs/project/NEW/mcp_log_server_architecture.md`
+- FastMCP log/VPS agent server planning or collector replacement -> `infra/docs/project/analysis/mcp_log_server_architecture.md`
+- Cloudflare CDN/R2 image migration planning -> `infra/docs/project/analysis/cloudflare_cdn_image_migration_analysis.md`
+- Image performance work that must preserve detail -> `infra/docs/project/analysis/TODO.md`
 - SSH tunnel or pgAdmin access to the VPS PostgreSQL DB -> `infra/docs/project/vps_postgres_ssh_tunneling.md`
 - Production release procedure -> `infra/scripts/README.md`
 - SSR architecture direction -> `infra/docs/project/SSR Migration/STAGE-1_ssr_migration.md`

--- a/backend/api_tests.http
+++ b/backend/api_tests.http
@@ -91,7 +91,7 @@ Content-Type: {{contentType}}
 
 ### Test 14: Middleware - POST to exact router path with trailing slash (should work if enabled)
 ### Expected: 201 Created (if form enabled) OR 400 Bad Request (if form disabled)
-### This tests that middleware checks exact DRF router path: /api/v1/contact/
+### This tests that middleware checks exact DRF router path: /v1/contact/
 POST {{baseUrl}}/contact/
 Content-Type: {{contentType}}
 
@@ -99,7 +99,7 @@ Content-Type: {{contentType}}
   "name": "Middleware Test User",
   "email": "middleware.test@example.com",
   "subject": "Middleware Test - Exact Path",
-  "message": "Testing middleware with exact router path /api/v1/contact/"
+  "message": "Testing middleware with exact router path /v1/contact/"
 }
 
 ### Test 15: Middleware - POST to path without trailing slash (should be ignored by middleware)
@@ -112,7 +112,7 @@ Content-Type: {{contentType}}
   "name": "Middleware Test User",
   "email": "middleware.test@example.com",
   "subject": "Middleware Test - No Trailing Slash",
-  "message": "Testing middleware with path without trailing slash /api/v1/contact"
+  "message": "Testing middleware with path without trailing slash /v1/contact"
 }
 
 ### Test 16: Middleware - GET to contact endpoint (should be ignored by middleware)
@@ -150,7 +150,7 @@ Content-Type: {{contentType}}
   "name": "Middleware Test User",
   "email": "middleware.test@example.com",
   "subject": "Middleware Test - Detail Endpoint",
-  "message": "Testing middleware with detail endpoint /api/v1/contact/123/"
+  "message": "Testing middleware with detail endpoint /v1/contact/123/"
 }
 
 ### Test 20: Middleware - POST to different path (should be ignored by middleware)
@@ -163,7 +163,7 @@ Content-Type: {{contentType}}
   "name": "Middleware Test User",
   "email": "middleware.test@example.com",
   "subject": "Middleware Test - Different Path",
-  "message": "Testing middleware with different path /api/v1/profile/"
+  "message": "Testing middleware with different path /v1/profile/"
 }
 
 ### ============================================================

--- a/backend/astrophotography/tests/test_views.py
+++ b/backend/astrophotography/tests/test_views.py
@@ -736,6 +736,7 @@ class TestAstroImageSecureView:
         response: Response = api_client.get(url, params)
         assert response.status_code == status.HTTP_200_OK
         assert response.has_header("X-Accel-Redirect")
+        assert response["Cache-Control"] == "private, no-store, max-age=0"
         serving_field = astro_image.original_webp_field or astro_image.original_field
         assert f"/protected_media/{serving_field.name}" == response["X-Accel-Redirect"]
 
@@ -757,6 +758,7 @@ class TestAstroImageSecureView:
 
         assert response.status_code == status.HTTP_200_OK
         assert response.has_header("X-Accel-Redirect")
+        assert response["Cache-Control"] == "private, no-store, max-age=0"
         serving_field = astro_image.original_webp_field or astro_image.original_field
         assert response["X-Accel-Redirect"] == f"/protected_media/{serving_field.name}"
 
@@ -821,6 +823,7 @@ class TestAstroImageAdminSecureMediaView:
         astro_image.refresh_from_db()
         assert response.status_code == status.HTTP_200_OK
         assert "X-Accel-Redirect" in response
+        assert response["Cache-Control"] == "private, no-store, max-age=0"
         assert response["X-Accel-Redirect"] == f"/protected_media/{astro_image.original.name}"
 
     def test_admin_secure_media_view_forbidden_anonymous(

--- a/backend/core/tests/test_admin_media_urls.py
+++ b/backend/core/tests/test_admin_media_urls.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
+from django.conf import settings
 from django.http import Http404, HttpResponse
 from django.test import RequestFactory, SimpleTestCase
 
@@ -13,20 +14,29 @@ class SafeServeTests(SimpleTestCase):
         self.factory = RequestFactory()
 
     def test_blocks_logs_directory(self):
-        request = self.factory.get("/media/logs/example.txt")
+        request = self.factory.get(
+            "/media/logs/example.txt",
+            HTTP_HOST=settings.ADMIN_DOMAIN,
+        )
 
         with pytest.raises(Http404):
             safe_serve(request, "logs/example.txt", document_root="/tmp")
 
     def test_blocks_images_directory(self):
-        request = self.factory.get("/media/images/example.jpg")
+        request = self.factory.get(
+            "/media/images/example.jpg",
+            HTTP_HOST=settings.ADMIN_DOMAIN,
+        )
 
         with pytest.raises(Http404):
             safe_serve(request, "images/example.jpg", document_root="/tmp")
 
     @patch("settings.urls.serve", return_value=HttpResponse("ok"))
     def test_allows_about_me_images_directory(self, mock_serve):
-        request = self.factory.get("/media/about_me_images/example.jpg")
+        request = self.factory.get(
+            "/media/about_me_images/example.jpg",
+            HTTP_HOST=settings.ADMIN_DOMAIN,
+        )
 
         response = safe_serve(request, "about_me_images/example.jpg", document_root="/tmp")
 
@@ -37,3 +47,12 @@ class SafeServeTests(SimpleTestCase):
             document_root="/tmp",
             show_indexes=False,
         )
+
+    def test_blocks_non_admin_host(self):
+        request = self.factory.get(
+            "/media/about_me_images/example.jpg",
+            HTTP_HOST=settings.SITE_DOMAIN,
+        )
+
+        with pytest.raises(Http404):
+            safe_serve(request, "about_me_images/example.jpg", document_root="/tmp")

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -114,7 +114,7 @@ class SecureMediaView(APIView):
         Since we return a raw HttpResponse (X-Accel-Redirect),
         DRF's renderer negotiation is unnecessary and can cause 406 errors.
         """
-        return (renderers.StaticHTMLRenderer(), "text/html")
+        return renderers.StaticHTMLRenderer(), "text/html"
 
     def get_object(self) -> Model:
         raise NotImplementedError("Subclasses must implement get_object")
@@ -186,6 +186,7 @@ class SecureMediaView(APIView):
         response["X-Accel-Redirect"] = redirect_uri
         response["Content-Type"] = ""  # Let Nginx determine the content type
         response["Content-Disposition"] = f'{self.content_disposition}; filename="{filename}"'
+        response["Cache-Control"] = "private, no-store, max-age=0"
         logger.info(
             f"Serving secure media via Nginx redirect: {redirect_uri} "
             f"as {filename} ({self.content_disposition})"

--- a/backend/inbox/middleware.py
+++ b/backend/inbox/middleware.py
@@ -16,9 +16,8 @@ class ContactFormKillSwitchMiddleware(MiddlewareMixin):
     Should be placed early in MIDDLEWARE list for maximum efficiency.
     """
 
-    # Path to check (contact form endpoint)
-    # DRF DefaultRouter always creates URLs with trailing slashes: /api/v1/contact/
-    CONTACT_PATH = "/api/v1/contact/"
+    # DRF DefaultRouter always creates URLs with trailing slashes.
+    CONTACT_PATH = "/v1/contact/"
 
     def process_request(self, request: HttpRequest) -> JsonResponse | None:
         """
@@ -26,11 +25,11 @@ class ContactFormKillSwitchMiddleware(MiddlewareMixin):
         Returns JsonResponse if form is disabled, None to continue processing.
 
         Note: DRF DefaultRouter creates consistent URLs with trailing slashes.
-        We check for the exact router-created path: /api/v1/contact/
+        We check for the exact router-created path: /v1/contact/
         """
         # Only check POST requests to exact contact endpoint
-        # Router creates: /api/v1/contact/ (list/create)
-        # and /api/v1/contact/{id}/ (detail/update/delete)
+        # Router creates: /v1/contact/ (list/create)
+        # and /v1/contact/{id}/ (detail/update/delete)
         # We only want to check the base endpoint for form submissions
         if request.method != "POST" or request.path != self.CONTACT_PATH:
             return None

--- a/backend/inbox/tests/test_middleware.py
+++ b/backend/inbox/tests/test_middleware.py
@@ -17,7 +17,7 @@ def test_kill_switch_middleware_allows_post_when_enabled(
 ) -> None:
     """Test kill_switch_middleware allows POST requests when form is enabled"""
     LandingPageSettingsFactory(contact_form_enabled=True)
-    request = request_factory.post("/api/v1/contact/")
+    request = request_factory.post("/v1/contact/")
     response = kill_switch_middleware.process_request(request)
 
     assert response is None, "Middleware should allow request when enabled"
@@ -31,7 +31,7 @@ def test_kill_switch_middleware_blocks_post_when_disabled(
     """Test kill_switch_middleware blocks POST requests when form is disabled"""
     LandingPageSettingsFactory(contact_form_enabled=False)
 
-    request = request_factory.post("/api/v1/contact/")
+    request = request_factory.post("/v1/contact/")
     response = kill_switch_middleware.process_request(request)
 
     assert response is not None, "Middleware should block request when disabled"
@@ -54,7 +54,7 @@ def test_kill_switch_middleware_ignores_non_post_requests(
     )  # Disabled, but should still allow non-POST
 
     for method in ["GET", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]:
-        request = getattr(request_factory, method.lower())("/api/v1/contact/")
+        request = getattr(request_factory, method.lower())("/v1/contact/")
         response = kill_switch_middleware.process_request(request)
         assert response is None, f"Middleware should ignore {method} requests"
 
@@ -68,12 +68,12 @@ def test_kill_switch_middleware_only_checks_contact_endpoint(
     LandingPageSettingsFactory(contact_form_enabled=False)
 
     other_paths = [
-        "/api/v1/profile/",
-        "/api/v1/image/",
-        "/api/v1/admin/",
-        "/api/v1/contact-messages/",  # Different endpoint
-        "/api/v1/contact",  # Missing trailing slash (not router path)
-        "/api/v1/contact/123/",  # Detail endpoint (not base endpoint)
+        "/v1/profile/",
+        "/v1/image/",
+        "/v1/admin/",
+        "/v1/contact-messages/",  # Different endpoint
+        "/v1/contact",  # Missing trailing slash (not router path)
+        "/v1/contact/123/",  # Detail endpoint (not base endpoint)
         "/",
     ]
 
@@ -91,9 +91,9 @@ def test_kill_switch_middleware_only_checks_exact_router_path(
     """Test kill_switch_middleware only checks exact DRF router path with trailing slash"""
     LandingPageSettingsFactory(contact_form_enabled=False)
 
-    # DRF router always creates URLs with trailing slashes: /api/v1/contact/
-    exact_router_path = "/api/v1/contact/"
-    path_without_slash = "/api/v1/contact"
+    # DRF router always creates URLs with trailing slashes: /v1/contact/
+    exact_router_path = "/v1/contact/"
+    path_without_slash = "/v1/contact"
 
     # Exact router path should be blocked when disabled
     request_with_slash = request_factory.post(exact_router_path)
@@ -121,7 +121,7 @@ def test_kill_switch_middleware_logs_blocked_requests(
 
     LandingPageSettingsFactory(contact_form_enabled=False)
 
-    request = request_factory.post("/api/v1/contact/")
+    request = request_factory.post("/v1/contact/")
     response = kill_switch_middleware.process_request(request)
 
     assert response is not None

--- a/backend/monitoring/services.py
+++ b/backend/monitoring/services.py
@@ -141,14 +141,14 @@ class ProbeBlockingContextBuilder:
     def _load_fail2ban_policy(cls) -> JSONObject:
         default_policy: JSONObject = {
             "portfolio-nginx-probes": {
-                "findtime": "10m",
+                "findtime": "1m",
                 "maxretry": 3,
-                "bantime": "7d",
+                "bantime": "-1",
             },
             "portfolio-traefik-probes": {
-                "findtime": "10m",
+                "findtime": "1m",
                 "maxretry": 3,
-                "bantime": "7d",
+                "bantime": "-1",
             },
         }
         if not cls.JAIL_CONFIG_PATH.exists():
@@ -163,9 +163,9 @@ class ProbeBlockingContextBuilder:
                 continue
             maxretry = _json_int(parser.get(jail_name, "maxretry", fallback="3"), default=3)
             policy[jail_name] = {
-                "findtime": parser.get(jail_name, "findtime", fallback="10m"),
+                "findtime": parser.get(jail_name, "findtime", fallback="1m"),
                 "maxretry": maxretry,
-                "bantime": parser.get(jail_name, "bantime", fallback="7d"),
+                "bantime": parser.get(jail_name, "bantime", fallback="-1"),
             }
         return policy
 

--- a/backend/monitoring/tests/test_admin.py
+++ b/backend/monitoring/tests/test_admin.py
@@ -61,6 +61,7 @@ class TestLogAnalysisAdminSecureMediaView:
         response = admin_client.get(url, params)
         assert response.status_code == 200
         assert "X-Accel-Redirect" in response
+        assert response["Cache-Control"] == "private, no-store, max-age=0"
         assert response["X-Accel-Redirect"] == f"/protected_media/{log_analysis.backend_logs.name}"
 
     def test_admin_secure_media_view_forbidden_anonymous(

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,7 +9,7 @@ description = "Portfolio backend with Django REST Framework"
 readme = "README.md"
 requires-python = ">=3.13,<4.0"
 dependencies = [
-    "django==6.0.4",
+    "django==6.0.5",
     "djangorestframework==3.17.1",
     "pillow==12.2.0",
     "django-environ==0.13.0",

--- a/backend/settings/base.py
+++ b/backend/settings/base.py
@@ -65,7 +65,7 @@ SECRET_KEY = env("SECRET_KEY", default=cast(Any, "django-insecure-development-ke
 SECURE_SSL_REDIRECT = env.bool("SECURE_SSL_REDIRECT", default=not DEBUG)
 SESSION_COOKIE_SECURE = env.bool("SESSION_COOKIE_SECURE", default=True)
 
-SECURE_HSTS_SECONDS = env.bool("SECURE_HSTS_SECONDS", default=31536000 if not DEBUG else 0)
+SECURE_HSTS_SECONDS = env.int("SECURE_HSTS_SECONDS", default=31536000 if not DEBUG else 0)
 SECURE_HSTS_INCLUDE_SUBDOMAINS = env.bool("SECURE_HSTS_INCLUDE_SUBDOMAINS", default=not DEBUG)
 SECURE_HSTS_PRELOAD = env.bool("SECURE_HSTS_PRELOAD", default=not DEBUG)
 # These headers are set by Nginx — disable Django's duplicates where possible

--- a/backend/settings/urls.py
+++ b/backend/settings/urls.py
@@ -88,7 +88,20 @@ urlpatterns = [
 
 
 def safe_serve(request, path, document_root=None, show_indexes=False):
-    if path.startswith("logs/"):
+    host = request.get_host().split(":")[0]
+    allowed_prefixes = (
+        "backgrounds/",
+        "avatars/",
+        "about_me_images/",
+        "thumbnails/",
+        "shop/",
+    )
+    blocked_prefixes = ("logs/", "images/")
+
+    if host != settings.ADMIN_DOMAIN:
+        raise Http404()
+
+    if path.startswith(blocked_prefixes) or not path.startswith(allowed_prefixes):
         raise Http404()
     return serve(
         request,

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -132,7 +132,7 @@ dev = [
 requires-dist = [
     { name = "beautifulsoup4", specifier = "==4.14.3" },
     { name = "celery", extras = ["redis"], specifier = "==5.6.3" },
-    { name = "django", specifier = "==6.0.4" },
+    { name = "django", specifier = "==6.0.5" },
     { name = "django-axes", specifier = "==8.3.1" },
     { name = "django-ckeditor-5", specifier = "==0.2.20" },
     { name = "django-cors-headers", specifier = "==4.9.0" },
@@ -574,16 +574,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "6.0.4"
+version = "6.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/b9/4155091ad1788b38563bd77a7258c0834e8c12a7f56f6975deaf54f8b61d/django-6.0.4.tar.gz", hash = "sha256:8cfa2572b3f2768b2e84983cf3c4811877a01edb64e817986ec5d60751c113ac", size = 10907407, upload-time = "2026-04-07T13:55:44.961Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f1/bf85f0d29ef76abf901f193fe8fef4769d3da7794197832bc30151c071d8/django-6.0.5.tar.gz", hash = "sha256:bc6d6872e98a2864c836e42edd644b362db311147dd5aa8d5b82ba7a032f5269", size = 10924131, upload-time = "2026-05-05T13:54:39.329Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/47/3d61d611609764aa71a37f7037b870e7bfb22937366974c4fd46cada7bab/django-6.0.4-py3-none-any.whl", hash = "sha256:14359c809fc16e8f81fd2b59d7d348e4d2d799da6840b10522b6edf7b8afc1da", size = 8368342, upload-time = "2026-04-07T13:55:37.999Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5b/1328f8b84fce040c404f76822bf8c57d254e368e8cbd8bd67ec2b26d75f5/django-6.0.5-py3-none-any.whl", hash = "sha256:9d58a7cb49244e74c8e161d5e403a46d6209f1009ba40f5a66d6aa0d0786a8f0", size = 8368680, upload-time = "2026-05-05T13:54:33.532Z" },
 ]
 
 [[package]]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -45,6 +45,8 @@ x-backend-defaults: &backend-defaults
     SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE:-0.1}
     OPENAI_API_KEY: ${OPENAI_API_KEY}
     SKIP_PERMISSION_FIX: ${SKIP_PERMISSION_FIX:-false}
+    SSR_CACHE_INVALIDATION_URL: ${SSR_CACHE_INVALIDATION_URL:-http://fe:8080/internal/cache/invalidate}
+    SSR_CACHE_INVALIDATION_TOKEN: ${SSR_CACHE_INVALIDATION_TOKEN}
   depends_on:
     db:
       condition: service_healthy
@@ -179,8 +181,6 @@ services:
     restart: always
     environment:
       <<: *backend-defaults-env
-      SSR_CACHE_INVALIDATION_URL: ${SSR_CACHE_INVALIDATION_URL:-http://fe:8080/internal/cache/invalidate}
-      SSR_CACHE_INVALIDATION_TOKEN: ${SSR_CACHE_INVALIDATION_TOKEN}
     volumes:
       - prod_media_data:/app/media
       - prod_static_data:/app/staticfiles
@@ -198,8 +198,6 @@ services:
     restart: "no"
     environment:
       <<: *backend-defaults-env
-      SSR_CACHE_INVALIDATION_URL: ${SSR_CACHE_INVALIDATION_URL:-http://fe:8080/internal/cache/invalidate}
-      SSR_CACHE_INVALIDATION_TOKEN: ${SSR_CACHE_INVALIDATION_TOKEN}
     command: >
       sh -c "
         python manage.py migrate --noinput &&
@@ -250,7 +248,7 @@ services:
       - "traefik.http.routers.portfolio-prod-www.entrypoints=websecure"
       - "traefik.http.routers.portfolio-prod-www.tls=true"
       - "traefik.http.routers.portfolio-prod-www.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.portfolio-prod-www.middlewares=portfolio-prod-www-redirect"
+      - "traefik.http.routers.portfolio-prod-www.middlewares=public-security@file,portfolio-prod-www-redirect"
       - "traefik.http.routers.portfolio-prod-www.service=noop@internal"
       - "traefik.http.middlewares.portfolio-prod-www-redirect.redirectregex.regex=^https://www\\.(.+)"
       - "traefik.http.middlewares.portfolio-prod-www-redirect.redirectregex.replacement=https://$${1}"

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -43,6 +43,8 @@ x-backend-defaults: &backend-defaults
     CELERY_BROKER_URL: redis://redis:6379/0
     CELERY_RESULT_BACKEND: redis://redis:6379/0
     SKIP_PERMISSION_FIX: ${SKIP_PERMISSION_FIX:-false}
+    SSR_CACHE_INVALIDATION_URL: ${SSR_CACHE_INVALIDATION_URL:-http://fe:8080/internal/cache/invalidate}
+    SSR_CACHE_INVALIDATION_TOKEN: ${SSR_CACHE_INVALIDATION_TOKEN}
   depends_on:
     db:
       condition: service_healthy
@@ -156,8 +158,6 @@ services:
     restart: always
     environment:
       <<: *backend-defaults-env
-      SSR_CACHE_INVALIDATION_URL: ${SSR_CACHE_INVALIDATION_URL:-http://fe:8080/internal/cache/invalidate}
-      SSR_CACHE_INVALIDATION_TOKEN: ${SSR_CACHE_INVALIDATION_TOKEN}
     volumes:
       - portfolio_staging_media_data:/app/media
       - portfolio_staging_static_data:/app/staticfiles
@@ -180,8 +180,6 @@ services:
     restart: "no"
     environment:
       <<: *backend-defaults-env
-      SSR_CACHE_INVALIDATION_URL: ${SSR_CACHE_INVALIDATION_URL:-http://fe:8080/internal/cache/invalidate}
-      SSR_CACHE_INVALIDATION_TOKEN: ${SSR_CACHE_INVALIDATION_TOKEN}
     command: >
       sh -c "
         python manage.py migrate --noinput &&

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11219,9 +11219,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3863,9 +3863,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -11323,12 +11323,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -11338,13 +11338,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/frontend/src/__tests__/pwaBuildOptions.test.ts
+++ b/frontend/src/__tests__/pwaBuildOptions.test.ts
@@ -1,0 +1,11 @@
+import { createPwaOptions } from '../utils/pwaBuildOptions';
+
+describe('PWA build options', () => {
+  it('does not let the service worker serve the static Vite shell for SSR navigations', () => {
+    const options = createPwaOptions('production', 'Portfolio Owner');
+
+    expect(options.injectRegister).toBe(false);
+    expect(options.workbox?.navigateFallback).toBe('');
+    expect(options.workbox?.globIgnores).toContain('**/index.html');
+  });
+});

--- a/frontend/src/components/AstroGallery.tsx
+++ b/frontend/src/components/AstroGallery.tsx
@@ -24,7 +24,6 @@ import { APP_ROUTES } from '../api/constants';
 import { NotFoundError } from '../api/errors';
 import { useCategories } from '../hooks/useCategories';
 import { useBackground } from '../hooks/useBackground';
-import { useImageUrls } from '../hooks/useImageUrls';
 import {
   getAstroImageNotFoundQueryKey,
   useAstroImageDetail,
@@ -159,9 +158,6 @@ const AstroGallery: React.FC = () => {
     isLoading: isModalImageLoading,
     error: modalImageError,
   } = useAstroImageDetail(imgSlug || null);
-
-  // Pre-fetch all signed urls
-  useImageUrls();
 
   const error = queryError ? 'Failed to fetch gallery images.' : null;
   const isInitialLoading = isImagesLoading && images.length === 0 && !error;

--- a/frontend/src/utils/pwaBuildOptions.ts
+++ b/frontend/src/utils/pwaBuildOptions.ts
@@ -1,0 +1,49 @@
+import type { VitePWAOptions } from 'vite-plugin-pwa';
+
+export function createPwaOptions(
+  appEnvironment: string,
+  projectOwner = 'Portfolio Owner'
+): Partial<VitePWAOptions> {
+  const owner = projectOwner || 'Portfolio Owner';
+
+  return {
+    registerType: 'autoUpdate',
+    injectRegister: false,
+    workbox: {
+      cleanupOutdatedCaches: true,
+      clientsClaim: true,
+      skipWaiting: true,
+      navigateFallback: '',
+      globIgnores: ['**/index.html'],
+    },
+    includeAssets: ['favicon.ico', 'robots.txt', 'logo192.png', 'logo512.png'],
+    manifest: {
+      short_name: owner,
+      name: `${owner} - Portfolio & Astrophotography`,
+      icons: [
+        {
+          src: 'favicon.ico',
+          sizes: '64x64 32x32 24x24 16x16',
+          type: 'image/x-icon',
+        },
+        {
+          src: 'logo192.png',
+          type: 'image/png',
+          sizes: '192x192',
+        },
+        {
+          src: 'logo512.png',
+          type: 'image/png',
+          sizes: '512x512',
+        },
+      ],
+      start_url: '/',
+      display: 'standalone',
+      theme_color: '#02040a',
+      background_color: '#02040a',
+    },
+    devOptions: {
+      enabled: ['development', 'dev', 'local'].includes(appEnvironment),
+    },
+  };
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,6 +8,7 @@ import type {
 } from 'vite';
 import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
+import { createPwaOptions } from './src/utils/pwaBuildOptions';
 
 export default defineConfig(({ isSsrBuild }: ConfigEnv) => {
   const appEnvironment =
@@ -107,46 +108,7 @@ export default defineConfig(({ isSsrBuild }: ConfigEnv) => {
       react(),
       criticalPathPlugin,
       enablePwa &&
-        VitePWA({
-          registerType: 'autoUpdate',
-          injectRegister: 'script-defer',
-          workbox: {
-            cleanupOutdatedCaches: true,
-            clientsClaim: true,
-            skipWaiting: true,
-          },
-          includeAssets: [
-            'favicon.ico',
-            'robots.txt',
-            'logo192.png',
-            'logo512.png',
-          ],
-          manifest: {
-            short_name: process.env.PROJECT_OWNER,
-            name: `${process.env.PROJECT_OWNER} - Portfolio & Astrophotography`,
-            icons: [
-              {
-                src: 'favicon.ico',
-                sizes: '64x64 32x32 24x24 16x16',
-                type: 'image/x-icon',
-              },
-              {
-                src: 'logo192.png',
-                type: 'image/png',
-                sizes: '192x192',
-              },
-              {
-                src: 'logo512.png',
-                type: 'image/png',
-                sizes: '512x512',
-              },
-            ],
-            start_url: '/',
-            display: 'standalone',
-            theme_color: '#02040a',
-            background_color: '#02040a',
-          },
-        }),
+        VitePWA(createPwaOptions(appEnvironment, process.env.PROJECT_OWNER)),
     ].filter(Boolean),
     css: {
       modules: {

--- a/infra/docs/prod/fail2ban_probe_blocker_playbook.md
+++ b/infra/docs/prod/fail2ban_probe_blocker_playbook.md
@@ -2,7 +2,8 @@
 
 Use this when enabling or operating production probe blocking on the VPS.
 
-Current default ban window for the repo-managed probe jails is 7 days.
+Current default policy for the repo-managed probe jails is 3 matching probes
+from the same IP within 1 minute, followed by a permanent ban.
 
 ## Install / Enable
 
@@ -26,6 +27,12 @@ The installer now detects the active nginx access-log path automatically and ins
 The host `fail2ban` log remains at `/var/log/fail2ban.log`, which is also the
 path consumed by the collector when monitoring snapshots include firewall
 activity.
+
+The nginx container also mounts the downloaded user-agent blocklist at
+`/etc/nginx/blocklist`. That blocklist rejects known bad user agents. The
+fail2ban probe jails use access logs instead: they watch blocked sensitive path
+requests, hidden-file requests, prohibited script/archive extensions, and common
+CMS/PHP probe paths.
 
 ## After Repo Changes
 
@@ -100,6 +107,10 @@ Expected result:
 - `Currently banned: 1`
 - the offending IP appears in `Banned IP list`
 - `/var/log/fail2ban.log` shows `NOTICE [portfolio-nginx-probes] Ban <ip>`
+
+The same policy applies to the Traefik probe jail for matching direct-IP or
+host-header probes: 3 matching requests from one IP within 1 minute, then a
+permanent ban.
 
 ## Monitor
 

--- a/infra/nginx/static_server.conf
+++ b/infra/nginx/static_server.conf
@@ -131,7 +131,6 @@ http {
 
         # Block hidden files and directories
         location ~ /\.(?!well-known).* {
-            access_log off;
             log_not_found off;
             error_page 418 =404 /404.html;
             return 418;
@@ -139,14 +138,12 @@ http {
 
         # Block prohibited extensions and scripts
         location ~ \.(php|py|pl|sh|lua|sql|cgi|bak|old|ini|7z|zip|rar|tar|gz)$ {
-            access_log off;
             log_not_found off;
             return 404;
         }
 
         # Block common CMS and exploit-probing paths
         location ~* /(wp-admin|wp-login|wp-content|xmlrpc\.php|setup\.php|config\.php|eval-stdin\.php) {
-            access_log off;
             log_not_found off;
             return 404;
         }
@@ -205,7 +202,6 @@ location ^~ /protected_media/ {
 
         # Block hidden files and directories
         location ~ /\.(?!well-known).* {
-            access_log off;
             log_not_found off;
             error_page 418 =404 /404.html;
             return 418;
@@ -213,14 +209,12 @@ location ^~ /protected_media/ {
 
         # Block prohibited extensions and scripts
         location ~ \.(php|py|pl|sh|lua|sql|cgi|bak|old|ini|7z|zip|rar|tar|gz)$ {
-            access_log off;
             log_not_found off;
             return 404;
         }
 
         # Block common CMS and exploit-probing paths
         location ~* /(wp-admin|wp-login|wp-content|xmlrpc\.php|setup\.php|config\.php|eval-stdin\.php) {
-            access_log off;
             log_not_found off;
             return 404;
         }
@@ -273,6 +267,7 @@ location ^~ /protected_media/ {
         location ~ ^/app/image-files/(.+)$ {
             limit_req zone=api_limit burst=50 nodelay;
             rewrite ^/app/image-files/(.*)$ /image-files/$1 break;
+            add_header Cache-Control "private, no-store, max-age=0" always;
             proxy_pass http://backend_upstream;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;

--- a/infra/scripts/README.md
+++ b/infra/scripts/README.md
@@ -207,6 +207,11 @@ Files:
 
 The nginx jail covers probes that reach nginx on the public domain.
 The Traefik jail covers unmatched direct-IP and host-header probes before they reach nginx.
+Both jails ban after 3 matching probes from the same IP within 1 minute, and
+the ban is permanent (`bantime = -1`). The nginx container also mounts the
+downloaded bad-bot user-agent blocklist at `/etc/nginx/blocklist`; the fail2ban
+jails do not read that mounted file directly, but they do watch access-log
+entries for the same sensitive-path families nginx blocks.
 
 Typical host setup:
 

--- a/infra/scripts/release/test_deploy_container_selection.sh
+++ b/infra/scripts/release/test_deploy_container_selection.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
+
+cat > "${tmp_dir}/docker" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$1" != "ps" ]]; then
+  echo "unexpected docker command: $*" >&2
+  exit 2
+fi
+
+expected=(
+  "ps"
+  "--filter"
+  "label=com.docker.compose.project=portfolio-stage"
+  "--filter"
+  "label=com.docker.compose.service=be"
+  "--filter"
+  "label=com.docker.compose.oneoff=False"
+  "--format"
+  "{{.Names}}"
+)
+
+if [[ "$*" != "${expected[*]}" ]]; then
+  echo "unexpected docker ps args: $*" >&2
+  exit 2
+fi
+
+printf '%s\n' "portfolio-stage-be-1"
+STUB
+chmod +x "${tmp_dir}/docker"
+
+PATH="${tmp_dir}:${PATH}"
+source "${REPO_ROOT}/infra/scripts/utils.sh"
+
+actual="$(get_compose_service_containers "portfolio-stage" "be")"
+expected="portfolio-stage-be-1"
+
+if [[ "${actual}" != "${expected}" ]]; then
+  echo "expected only the long-running backend container"
+  echo "expected: ${expected}"
+  echo "actual: ${actual}"
+  exit 1
+fi

--- a/infra/scripts/security/fail2ban/filter.d/portfolio-nginx-sensitive-probes.conf
+++ b/infra/scripts/security/fail2ban/filter.d/portfolio-nginx-sensitive-probes.conf
@@ -1,5 +1,7 @@
 [Definition]
-failregex = ^.*"remote_addr": "<HOST>", .*"request": "[A-Z]+ /(?:[^" ]*/)*\.env[^" ]* HTTP/[0-9.]+"\, .*"status": "(?:403|404)".*$
-            ^.*"remote_addr": "<HOST>", .*"request": "[A-Z]+ /(?:[^" ]*/)*\.git/config[^" ]* HTTP/[0-9.]+"\, .*"status": "(?:403|404)".*$
-            ^.*"remote_addr": "<HOST>", .*"request": "[A-Z]+ /(?:wp-admin|wp-login|wp-content|xmlrpc\.php|phpMyAdmin|phpmyadmin|setup\.php|config\.php|eval-stdin\.php)(?:[/?][^" ]*)? HTTP/[0-9.]+"\, .*"status": "(?:403|404)".*$
+failregex = ^.*"remote_addr": "<HOST>", .*"request": "[A-Z]+ /(?:[^" ]*/)*\.env[^" ]* HTTP/[0-9.]+", .*"status": "(?:403|404)".*$
+            ^.*"remote_addr": "<HOST>", .*"request": "[A-Z]+ /(?:[^" ]*/)*\.git/config[^" ]* HTTP/[0-9.]+", .*"status": "(?:403|404)".*$
+            ^.*"remote_addr": "<HOST>", .*"request": "[A-Z]+ /(?:[^" ]*/)*\.(?!well-known)[^" ]* HTTP/[0-9.]+", .*"status": "(?:403|404)".*$
+            ^.*"remote_addr": "<HOST>", .*"request": "[A-Z]+ [^" ]*\.(?:php|py|pl|sh|lua|sql|cgi|bak|old|ini|7z|zip|rar|tar|gz)(?:[/?][^" ]*)? HTTP/[0-9.]+", .*"status": "(?:403|404)".*$
+            ^.*"remote_addr": "<HOST>", .*"request": "[A-Z]+ /(?:wp-admin|wp-login|wp-content|xmlrpc\.php|phpMyAdmin|phpmyadmin|setup\.php|config\.php|eval-stdin\.php)(?:[/?][^" ]*)? HTTP/[0-9.]+", .*"status": "(?:403|404)".*$
 ignoreregex =

--- a/infra/scripts/security/fail2ban/filter.d/portfolio-traefik-sensitive-probes.conf
+++ b/infra/scripts/security/fail2ban/filter.d/portfolio-traefik-sensitive-probes.conf
@@ -2,5 +2,7 @@
 datepattern = "time":"%%Y-%%m-%%dT%%H:%%M:%%S(?:\.%%f)?(?:Z|[+-]%%H:%%M)"
 failregex = ^.*"ClientHost":"<HOST>".*"DownstreamStatus":(?:403|404).*"RequestPath":"/(?:[^"]*/)*\.env[^"]*".*$
             ^.*"ClientHost":"<HOST>".*"DownstreamStatus":(?:403|404).*"RequestPath":"/(?:[^"]*/)*\.git/config[^"]*".*$
+            ^.*"ClientHost":"<HOST>".*"DownstreamStatus":(?:403|404).*"RequestPath":"/(?:[^"]*/)*\.(?!well-known)[^"]*".*$
+            ^.*"ClientHost":"<HOST>".*"DownstreamStatus":(?:403|404).*"RequestPath":"[^"]*\.(?:php|py|pl|sh|lua|sql|cgi|bak|old|ini|7z|zip|rar|tar|gz)(?:[/?][^"]*)?".*$
             ^.*"ClientHost":"<HOST>".*"DownstreamStatus":(?:403|404).*"RequestPath":"/(?:wp-admin|wp-login|wp-content|xmlrpc\.php|phpMyAdmin|phpmyadmin|setup\.php|config\.php|eval-stdin\.php)(?:[/?][^"]*)?".*$
 ignoreregex =

--- a/infra/scripts/security/fail2ban/jail.d/portfolio-probe-blocker.local
+++ b/infra/scripts/security/fail2ban/jail.d/portfolio-probe-blocker.local
@@ -4,9 +4,9 @@ filter = portfolio-nginx-sensitive-probes
 backend = auto
 port = http,https
 logpath = __NGINX_ACCESS_LOG__
-findtime = 10m
+findtime = 1m
 maxretry = 3
-bantime = 7d
+bantime = -1
 
 [portfolio-traefik-probes]
 enabled = true
@@ -14,6 +14,6 @@ filter = portfolio-traefik-sensitive-probes
 backend = auto
 port = http,https
 logpath = /var/log/portfolio/traefik/access.log
-findtime = 10m
+findtime = 1m
 maxretry = 3
-bantime = 7d
+bantime = -1


### PR DESCRIPTION
# Harden security probes and protected media caching

## 🚀 Summary
This branch tightens production security handling for sensitive probe traffic,
protected media delivery, frontend deploy behavior, and dependency scanning.

It keeps blocked probe requests visible to fail2ban, prevents protected media
responses from being cached beyond authorization windows, fixes the React Router
audit finding, and reduces noisy release/deploy edge cases.

## 🐛 Fixes
- Keep denied sensitive-path probes visible to fail2ban by preserving nginx
  access logging for blocked probe locations.
- Mark signed image-file and secure media responses as private/no-store so
  protected media URLs are not cached beyond their authorization window.
- Remove eager signed-image URL prefetching from the gallery so protected image
  URLs are requested only when needed.
- Fix contact middleware path matching and HSTS integer parsing edge cases.
- Resolve the frontend dependency audit failure by updating the lockfile to
  `react-router-dom`/`react-router` 6.30.4.

## 🔧 Build / CI / Infra
- Add a deploy helper that selects only long-running Compose service containers,
  avoiding one-off `docker compose run` containers during health checks.
- Extract PWA build options into a testable module so the service worker does
  not serve the static Vite shell for SSR navigations.
- Update stage/prod compose and release docs for the hardened deployment flow.

## 🏗️ Infrastructure
- Tighten fail2ban probe filters for nginx and Traefik sensitive-path traffic.
- Switch high-confidence probe jails to permanent bans after repeated hits.
- Document remaining VPS security hardening follow-ups separately from this PR.